### PR TITLE
17471: Update VS launch file examples

### DIFF
--- a/docs/launch.example.json
+++ b/docs/launch.example.json
@@ -1,7 +1,5 @@
 {
-  // Use IntelliSense to learn about possible attributes.
-  // Hover to view descriptions of existing attributes.
-  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "comment": "Amalgam VSCode Debugging Examples (CMake built)",
   "version": "0.2.0",
   "configurations": [
     {
@@ -10,7 +8,7 @@
       "request": "launch",
       "program": "${command:cmake.launchTargetPath}",
       "args": [ "amlg_code/full_test.amlg" ],
-      "cwd": "${workspaceFolder}/Amalgam/",
+      "cwd": "${workspaceFolder}/src/Amalgam/",
       "stopAtEntry": false
     },
     {
@@ -19,7 +17,17 @@
       "request": "launch",
       "program": "${command:cmake.launchTargetPath}",
       "args": [ "amlg_code/full_test.amlg" ],
-      "cwd": "${workspaceFolder}/Amalgam/",
+      "cwd": "${workspaceFolder}/src/Amalgam/",
+      "stopAtEntry": false
+    },
+    {
+      "name": "debug-macos",
+      "type": "cppdbg",
+      "request": "launch",
+      "program": "${command:cmake.launchTargetPath}",
+      "args": [ "amlg_code/full_test.amlg" ],
+      "cwd": "${workspaceFolder}/src/Amalgam/",
+      "MIMode": "lldb",
       "stopAtEntry": false
     }
   ]

--- a/docs/launch.vs.example.json
+++ b/docs/launch.vs.example.json
@@ -1,52 +1,53 @@
 {
+  "comment": "Amalgam VisualStudio2022 Debugging Examples (CMake built)",
   "version": "0.2.1",
   "defaults": {},
   "configurations": [
     {
+      "comment": "Windows multi-threaded",
       "type": "exe",
       "project": "CMakeLists.txt",
       "projectTarget": "amalgam-mt.exe",
       "name": "amalgam-mt.exe",
-      "currentDir": "${workspaceRoot}/Amalgam/",
+      "currentDir": "${workspaceRoot}/src/Amalgam/",
       "args": [
         "amlg_code/full_test.amlg"
       ]
     },
     {
+      "comment": "Windows single threaded",
       "type": "exe",
       "project": "CMakeLists.txt",
       "projectTarget": "amalgam-st.exe",
       "name": "amalgam-st.exe",
-      "currentDir": "${workspaceRoot}/Amalgam/",
+      "currentDir": "${workspaceRoot}/src/Amalgam/",
       "args": [
         "amlg_code/full_test.amlg"
       ]
     },
     {
+      "comment": "Remote liunx multi-threaded (WSL: http://aka.ms/vslinuxdebug)",
       "type": "cppgdb",
       "name": "amalgam-mt",
       "project": "CMakeLists.txt",
       "projectTarget": "amalgam-mt",
       "debuggerConfiguration": "gdb",
-      "cwd": "Amalgam/",
+      "cwd": "src/Amalgam/",
       "args": [
         "amlg_code/full_test.amlg"
-      ],
-      "comment": "Learn how to configure WSL debugging. For more info, see http://aka.ms/vslinuxdebug",
-      "env": {}
+      ]
     },
     {
+      "comment": "Remote liunx single threaded (WSL: http://aka.ms/vslinuxdebug)",
       "type": "cppgdb",
       "name": "amalgam-st",
       "project": "CMakeLists.txt",
       "projectTarget": "amalgam-st",
       "debuggerConfiguration": "gdb",
-      "cwd": "Amalgam/",
+      "cwd": "src/Amalgam/",
       "args": [
         "amlg_code/full_test.amlg"
-      ],
-      "comment": "Learn how to configure WSL debugging. For more info, see http://aka.ms/vslinuxdebug",
-      "env": {}
+      ]
     }
   ]
 }


### PR DESCRIPTION
Update VS and VSCode launch file examples with macOS examples and minor clean-up.