### PR TITLE
17747: Upgrades mac build to macOS 12 (Monterey), MAJOR

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -66,7 +66,7 @@ jobs:
         if-no-files-found: error
 
   build-macos:
-    runs-on: macos-11
+    runs-on: macos-12
     strategy:
       matrix:
         preset:
@@ -94,8 +94,8 @@ jobs:
           brew uninstall --ignore-dependencies libomp
           brew cleanup -s
           rm -rf `brew --cache`
-          brew fetch --force --bottle-tag=arm64_big_sur libomp@17.0.1
-          brew install `brew --cache --bottle-tag=arm64_big_sur libomp@17.0.1`
+          brew fetch --force --bottle-tag=arm64_big_sur libomp
+          brew install `brew --cache --bottle-tag=arm64_big_sur libomp`
         else
           brew install libomp
         fi

--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -94,8 +94,8 @@ jobs:
           brew uninstall --ignore-dependencies libomp
           brew cleanup -s
           rm -rf `brew --cache`
-          brew fetch --force --bottle-tag=arm64_big_sur libomp
-          brew install `brew --cache --bottle-tag=arm64_big_sur libomp`
+          brew fetch --force --bottle-tag=arm64_monterey libomp
+          brew install `brew --cache --bottle-tag=arm64_monterey libomp`
         else
           brew install libomp
         fi

--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -94,8 +94,8 @@ jobs:
           brew uninstall --ignore-dependencies libomp
           brew cleanup -s
           rm -rf `brew --cache`
-          brew fetch --force --bottle-tag=arm64_big_sur libomp
-          brew install `brew --cache --bottle-tag=arm64_big_sur libomp`
+          brew fetch --force --bottle-tag=arm64_big_sur libomp@17.0.1
+          brew install `brew --cache --bottle-tag=arm64_big_sur libomp@17.0.1`
         else
           brew install libomp
         fi

--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -90,12 +90,6 @@ jobs:
 
     - name: Install build dependencies
       run: |
-        echo "========================="
-        brew config
-        echo "========================="
-        brew doctor
-        echo "========================="
-
         if [ "${{ matrix.preset.arch }}" = "arm64" ]; then
           brew uninstall --ignore-dependencies libomp
           brew cleanup -s

--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -90,6 +90,12 @@ jobs:
 
     - name: Install build dependencies
       run: |
+        echo "========================="
+        brew config
+        echo "========================="
+        brew doctor
+        echo "========================="
+
         if [ "${{ matrix.preset.arch }}" = "arm64" ]; then
           brew uninstall --ignore-dependencies libomp
           brew cleanup -s

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -35,7 +35,7 @@
       "hidden": true,
       "description": "Sets macos os",
       "cacheVariables": {
-        "CMAKE_OSX_DEPLOYMENT_TARGET": "11"
+        "CMAKE_OSX_DEPLOYMENT_TARGET": "12"
       }
     },
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Though Amalgam is intended to support any C++17 compliant compiler, the current 
 * Linux:
     * Ubuntu 20.04, gcc-10
 * macOS (Darwin):
-    * macOS 12, AppleClang 13.0
+    * macOS 12, AppleClang 14.0
 * WASM:
     * Ubuntu 20.04, emscripten 3.1.32
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Though Amalgam is intended to support any C++17 compliant compiler, the current 
 * Linux:
     * Ubuntu 20.04, gcc-10
 * macOS (Darwin):
-    * macOS 11, AppleClang 13.0
+    * macOS 12, AppleClang 13.0
 * WASM:
     * Ubuntu 20.04, emscripten 3.1.32
 
@@ -154,7 +154,7 @@ Running the pre-built interpreter has specific runtime requirements per platform
 
 ##### macOS (Darwin)
 
-* macOS 11 or higher
+* macOS 12 or higher
 * Arch: amd64 or arm64
     * Specific arm64 builds: `armv8.4-a+simd` (M1 or later)
 

--- a/build/cmake/global_compiler_flags.cmake
+++ b/build/cmake/global_compiler_flags.cmake
@@ -73,8 +73,8 @@ elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" OR "${CMAKE_CXX_COMPILER_ID}" S
 elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang")
 
     set(IS_APPLECLANG True)
-    if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 13)
-        message(WARNING "AppleClang version '${CMAKE_CXX_COMPILER_VERSION}' < 13, usage is not officially supported")
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 14)
+        message(WARNING "AppleClang version '${CMAKE_CXX_COMPILER_VERSION}' < 14, usage is not officially supported")
     endif()
 
     string(APPEND CMAKE_CXX_FLAGS " -fPIC -fno-strict-aliasing -Wall -Wno-unknown-pragmas -Werror")

--- a/src/3rd_party/rapidyaml/rapidyaml-0.5.0.hpp
+++ b/src/3rd_party/rapidyaml/rapidyaml-0.5.0.hpp
@@ -1,8 +1,6 @@
 #ifndef _RYML_SINGLE_HEADER_AMALGAMATED_HPP_
 #define _RYML_SINGLE_HEADER_AMALGAMATED_HPP_
 
-#pragma clang diagnostic ignored "-Wunused-but-set-variable"
-
 //
 // Rapid YAML - a library to parse and emit YAML, and do it fast.
 //
@@ -197,6 +195,7 @@
      * @see http://stackoverflow.com/questions/32047685/variadic-macro-without-arguments */
 #   pragma clang diagnostic push
 #   pragma clang diagnostic ignored "-Wgnu-zero-variadic-macro-arguments" // warning: token pasting of ',' and __VA_ARGS__ is a GNU extension
+#   pragma clang diagnostic ignored "-Wunused-but-set-variable"
 #elif defined(__GNUC__)
     /* GCC also issues a warning for zero-args calls to variadic macros.
      * This warning is switched on with -pedantic and apparently there is no

--- a/src/3rd_party/rapidyaml/rapidyaml-0.5.0.hpp
+++ b/src/3rd_party/rapidyaml/rapidyaml-0.5.0.hpp
@@ -18384,7 +18384,7 @@ bool is_debugger_attached()
     // https://stackoverflow.com/questions/2200277/detecting-debugger-on-mac-os-x
     // Returns true if the current process is being debugged (either
     // running under the debugger or has a debugger attached post facto).
-    int                 junk;
+    int                 junk [[maybe_unused]];
     int                 mib[4];
     struct kinfo_proc   info;
     size_t              size;

--- a/src/3rd_party/rapidyaml/rapidyaml-0.5.0.hpp
+++ b/src/3rd_party/rapidyaml/rapidyaml-0.5.0.hpp
@@ -1,6 +1,8 @@
 #ifndef _RYML_SINGLE_HEADER_AMALGAMATED_HPP_
 #define _RYML_SINGLE_HEADER_AMALGAMATED_HPP_
 
+#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
+
 //
 // Rapid YAML - a library to parse and emit YAML, and do it fast.
 //
@@ -1675,18 +1677,18 @@ using index_sequence_for = make_index_sequence<sizeof...(_Tp)>;
 //********************************************************************************
 
 /* Copyright (c) 2011-2021, Scott Tsai
- * 
+ *
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -7403,11 +7405,11 @@ inline OStream& operator<< (OStream& os, basic_substring<C> s)
 // the Software, and to permit persons to whom the Software
 // is furnished to do so, subject to the following
 // conditions:
-// 
+//
 // The above copyright notice and this permission notice
 // shall be included in all copies or substantial portions
 // of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
 // ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
 // TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
@@ -8839,9 +8841,9 @@ namespace detail {
  * where
  *   p = log(5**q)/log(2) = q * log(5)/log(2)
  *
- * For negative values of q in (-400,0), we have that 
+ * For negative values of q in (-400,0), we have that
  *  f = (((152170 + 65536) * q ) >> 16);
- * is equal to 
+ * is equal to
  *   -ceil(p) + q
  * where
  *   p = log(5**-q)/log(2) = -q * log(5)/log(2)
@@ -8912,7 +8914,7 @@ adjusted_mantissa compute_float(int64_t q, uint64_t w)  noexcept  {
     // In some very rare cases, this could happen, in which case we might need a more accurate
     // computation that what we can provide cheaply. This is very, very unlikely.
     //
-    const bool inside_safe_exponent = (q >= -27) && (q <= 55); // always good because 5**q <2**128 when q>=0, 
+    const bool inside_safe_exponent = (q >= -27) && (q <= 55); // always good because 5**q <2**128 when q>=0,
     // and otherwise, for q<0, we have 5**-q<2**64 and the 128-bit reciprocal allows for exact computation.
     if(!inside_safe_exponent) {
       return compute_error_scaled<binary>(q, product.high, lz);
@@ -12137,7 +12139,7 @@ inline bool check_overflow(csubstr str, csubstr limit) noexcept
  */
 template<class T>
 auto overflows(csubstr str) noexcept
-    -> typename std::enable_if<std::is_unsigned<T>::value, bool>::type 
+    -> typename std::enable_if<std::is_unsigned<T>::value, bool>::type
 {
     C4_STATIC_ASSERT(std::is_integral<T>::value);
 
@@ -12201,7 +12203,7 @@ auto overflows(csubstr str) noexcept
  */
 template<class T>
 auto overflows(csubstr str)
-    -> typename std::enable_if<std::is_signed<T>::value, bool>::type 
+    -> typename std::enable_if<std::is_signed<T>::value, bool>::type
 {
     C4_STATIC_ASSERT(std::is_integral<T>::value);
     if(C4_UNLIKELY(str.len == 0))

--- a/src/3rd_party/rapidyaml/rapidyaml-0.5.0.hpp
+++ b/src/3rd_party/rapidyaml/rapidyaml-0.5.0.hpp
@@ -1,7 +1,7 @@
 #ifndef _RYML_SINGLE_HEADER_AMALGAMATED_HPP_
 #define _RYML_SINGLE_HEADER_AMALGAMATED_HPP_
 
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
+#pragma clang diagnostic ignored "-Wunused-but-set-variable"
 
 //
 // Rapid YAML - a library to parse and emit YAML, and do it fast.


### PR DESCRIPTION
Homebrew has stopped support for macOS 11 Big Sur. Apple's support will soon stop as well. Upgrade build boxes to use and target macOS 12 as minimum macOS supported.