### PR TITLE
17481: Removes MacOS-arm64 smoke test as release requirement

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -355,7 +355,6 @@ jobs:
       - smoke-test-linux-arm64
       - smoke-test-linux-arm64_8a
       - smoke-test-macos-amd64
-      - smoke-test-macos-arm64
       - smoke-test-windows-amd64
       - smoke-test-wasm64
     runs-on: ubuntu-latest


### PR DESCRIPTION
Since MacOS on arm64 is not yet supported by GitHub Actions runners, we are skipping the job for that smoke test. However, since it is still a requirement for the release job, the release job is skipped, too. This PR removes `smoke-test-macos-arm64` as a requirement for the release job.