### PR TITLE
18825: Adds NO_REENTRANCY_LOCKS to arm8a build

### DIFF
--- a/build/cmake/global_compiler_flags.cmake
+++ b/build/cmake/global_compiler_flags.cmake
@@ -58,13 +58,19 @@ elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" OR "${CMAKE_CXX_COMPILER_ID}" S
     endif()
 
     string(APPEND CMAKE_CXX_FLAGS " -fPIC -fno-strict-aliasing -Wall -Wno-unknown-pragmas -Werror")
-    #string(APPEND CMAKE_CXX_FLAGS " -Wpedantic -Wextra -Wabi") # Additional warnings that are fairly strict, not enabled right now
+    # TODO 1599: Additional warnings that are fairly strict, not enabled right now
+    #string(APPEND CMAKE_CXX_FLAGS " -Wpedantic -Wextra -Wabi")
 
     if(IS_ARM64)
         # See for discussion why set: https://stackoverflow.com/questions/52020305/what-exactly-does-gccs-wpsabi-option-do-what-are-the-implications-of-supressi
         string(APPEND CMAKE_CXX_FLAGS " -Wno-psabi")
+
+        if(IS_ARM64_8A)
+            add_compile_definitions(NO_REENTRANCY_LOCKS)
+        endif()
     endif()
 
+    # TODO 1599: WASM support is experimental, these flags will be cleaned up and auto-generated where possible
     if(IS_WASM)
         string(APPEND CMAKE_CXX_FLAGS " -sMEMORY64=2 -Wno-experimental -DSIMDJSON_NO_PORTABILITY_WARNING")
         string(APPEND CMAKE_EXE_LINKER_FLAGS " -sINVOKE_RUN=0 -sALLOW_MEMORY_GROWTH=1 -sINITIAL_MEMORY=65536000 -sMEMORY_GROWTH_GEOMETRIC_STEP=0.50 -sMODULARIZE=1 -sEXPORT_NAME=AmalgamRuntime -sENVIRONMENT=worker -sEXPORTED_RUNTIME_METHODS=cwrap,ccall,FS,setValue,getValue -sEXPORTED_FUNCTIONS=_malloc,_free,_LoadEntity,_StoreEntity,_ExecuteEntity,_ExecuteEntityJsonPtr,_DeleteEntity,_GetEntities,_SetRandomSeed,_SetJSONToLabel,_GetJSONPtrFromLabel,_SetSBFDataStoreEnabled,_IsSBFDataStoreEnabled,_GetVersionString,_SetMaxNumThreads,_GetMaxNumThreads --preload-file /wasm/tzdata@/tzdata --preload-file /wasm/etc@/etc")
@@ -78,7 +84,8 @@ elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang")
     endif()
 
     string(APPEND CMAKE_CXX_FLAGS " -fPIC -fno-strict-aliasing -Wall -Wno-unknown-pragmas -Werror")
-    #string(APPEND CMAKE_CXX_FLAGS " -Wpedantic -Wextra -Wabi") # Additional warnings that are fairly strict, not enabled right now
+    # TODO 1599: Additional warnings that are fairly strict, not enabled right now
+    #string(APPEND CMAKE_CXX_FLAGS " -Wpedantic -Wextra -Wabi")
 
 else()
 

--- a/build/powershell/Create-Amalgam-Version-Header.ps1
+++ b/build/powershell/Create-Amalgam-Version-Header.ps1
@@ -32,6 +32,8 @@ function Create-Amalgam-Version-Header {
     # Write new header:
     $HeaderFileOut = "$PSScriptRoot/../../src/Amalgam/AmalgamVersion.h"
     Set-Content -Path $HeaderFileOut -Value $NewHeaderContents
+
+    Write-Host "Done writing new version header: '$HeaderFileOut'"
 }
 
 Create-Amalgam-Version-Header

--- a/src/Amalgam/PlatformSpecific.cpp
+++ b/src/Amalgam/PlatformSpecific.cpp
@@ -1,6 +1,8 @@
 //project headers:
 #include "PlatformSpecific.h"
 
+#include "Concurrency.h"
+
 //system headers:
 #include <algorithm>
 #include <array>
@@ -313,7 +315,7 @@ bool Platform_ThreadsafeLocaltime(std::time_t time_value, std::tm &localized_tim
 #ifdef OS_WINDOWS
 	return localtime_s(&localized_time, &time_value) == 0; //MS swaps the values and returns the wrong thing
 #else // POSIX
-	return ::localtime_r(&time_value, *localized_time) != nullptr;
+	return ::localtime_r(&time_value, &localized_time) != nullptr;
 #endif
 }
 

--- a/src/Amalgam/PlatformSpecific.cpp
+++ b/src/Amalgam/PlatformSpecific.cpp
@@ -13,8 +13,8 @@
 
 #ifdef OS_WINDOWS
 
-	//disable std::wstring_convert deprecation warning: no replacement in C++17 so
-	// will require rework. 
+	// TODO 15993: disable std::wstring_convert deprecation warning: no replacement in C++17 so
+	// will require rework when we move to C++20. 
 	#pragma warning(disable: 4996)
 
 	#define NOMINMAX
@@ -307,26 +307,26 @@ void Platform_GenerateSecureRandomData(void *buffer, size_t length)
 #endif
 }
 
-void Platform_EnsurePreciseTiming()
+//performs localtime in a threadsafe manner
+bool Platform_ThreadsafeLocaltime(std::time_t time_value, std::tm &localized_time)
 {
-	//need to link to extra .libs for this
-#if defined(OS_WINDOWS) && defined(OS_WINDOWS_ACCURATE_SLEEP)
-	static bool time_resolution_initialized = false;
-	if(!time_resolution_initialized)
-	{
-		timeBeginPeriod(1);
-		time_resolution_initialized = true;
-	}
+#ifdef OS_WINDOWS
+	return localtime_s(&localized_time, &time_value) == 0; //MS swaps the values and returns the wrong thing
+#else // POSIX
+	return ::localtime_r(&time_value, *localized_time) != nullptr;
 #endif
 }
 
-//performs localtime in a threadsafe manner
-bool Platform_ThreadsafeLocaltime(std::time_t time_value, std::tm **localized_time)
+void Platform_Sleep(std::chrono::microseconds sleep_time_usec)
 {
-#ifdef OS_WINDOWS
-	return localtime_s(*localized_time, &time_value) == 0; //MS swaps the values and returns the wrong thing
-#else // POSIX
-	return ::localtime_r(&time_value, *localized_time) != nullptr;
+	//std::this_thread lives in the thread header. Instead of including that for all builds, use different
+	// sleep functions when compiling single threaded builds w/o re-entrant locks
+#ifndef NO_REENTRANCY_LOCKS
+	std::this_thread::sleep_for(sleep_time_usec);
+#elif defined(OS_WINDOWS)
+	Sleep(std::chrono::duration_cast<std::chrono::milliseconds>(sleep_time_usec).count());
+#else
+	usleep(sleep_time_usec.count());
 #endif
 }
 

--- a/src/Amalgam/PlatformSpecific.cpp
+++ b/src/Amalgam/PlatformSpecific.cpp
@@ -321,9 +321,9 @@ bool Platform_ThreadsafeLocaltime(std::time_t time_value, std::tm &localized_tim
 
 void Platform_Sleep(std::chrono::microseconds sleep_time_usec)
 {
-	//std::this_thread lives in the thread header. Instead of including that for all builds, use different
-	// sleep functions when compiling single threaded builds w/o re-entrant locks
-#ifndef NO_REENTRANCY_LOCKS
+	//std::this_thread lives in the thread header. Instead of including that for all builds, use OS
+	// sleep functions when not in multi-threaded builds.
+#if defined(MULTITHREAD_SUPPORT) || defined(MULTITHREAD_INTERFACE) || defined(_OPENMP)
 	std::this_thread::sleep_for(sleep_time_usec);
 #elif defined(OS_WINDOWS)
 	Sleep(std::chrono::duration_cast<std::chrono::milliseconds>(sleep_time_usec).count());

--- a/src/Amalgam/PlatformSpecific.h
+++ b/src/Amalgam/PlatformSpecific.h
@@ -184,18 +184,18 @@ std::string Platform_RunSystemCommand(std::string command, bool &successful_run,
 //returns a path to the home directory for the platform
 std::string Platform_GetHomeDirectory();
 
-//Returns true if resource is readable given whether must_exist is set.  Returns false if not, and sets error string to the reason
+//returns true if resource is readable given whether must_exist is set.  Returns false if not, and sets error string to the reason
 bool Platform_IsResourcePathAccessible(const std::string &resource_path, bool must_exist, std::string &error);
 
 //generates cryptographically secure random data into buffer to specified length
 void Platform_GenerateSecureRandomData(void *buffer, size_t length);
 
-//tells the OS that this process wants high-precision timing
-void Platform_EnsurePreciseTiming();
-
 //performs localtime in a threadsafe manner
 // returns true on success
 bool Platform_ThreadsafeLocaltime(std::time_t time_value, std::tm &localized_time);
+
+//sleeps for given amount time
+void Platform_Sleep(std::chrono::microseconds sleep_time_usec);
 
 //returns true if a debugger is present
 bool Platform_IsDebuggerPresent();

--- a/src/Amalgam/interpreter/InterpreterOpcodesBase.cpp
+++ b/src/Amalgam/interpreter/InterpreterOpcodesBase.cpp
@@ -145,8 +145,7 @@ EvaluableNodeReference Interpreter::InterpretNode_ENT_SYSTEM(EvaluableNode *en, 
 			sleep_time_usec = std::chrono::microseconds(static_cast<size_t>(1000000.0 * sleep_time_sec));
 		}
 
-		Platform_EnsurePreciseTiming();
-		std::this_thread::sleep_for(sleep_time_usec);
+		Platform_Sleep(sleep_time_usec);
 	}
 	else if(command == "version")
 	{


### PR DESCRIPTION
* Removes potential for illegal instructions by compiling with NO_REENTRANCY_LOCKS on arm8a.
* Adds platform specific sleep needed for NO_REENTRANCY_LOCKS addition.
* Removes obsolete Platform_EnsurePreciseTiming method.
* Adds missing TODOs for commented out CMake configs and code
* Adds done message to create version script to know when that step is completed.