### PR TITLE
19511: Adds LoadEntityLegacy to C API for interop with legacy callers, MINOR

### DIFF
--- a/build/cmake/global_compiler_flags.cmake
+++ b/build/cmake/global_compiler_flags.cmake
@@ -73,7 +73,7 @@ elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" OR "${CMAKE_CXX_COMPILER_ID}" S
     # TODO 1599: WASM support is experimental, these flags will be cleaned up and auto-generated where possible
     if(IS_WASM)
         string(APPEND CMAKE_CXX_FLAGS " -sMEMORY64=2 -Wno-experimental -DSIMDJSON_NO_PORTABILITY_WARNING")
-        string(APPEND CMAKE_EXE_LINKER_FLAGS " -sINVOKE_RUN=0 -sALLOW_MEMORY_GROWTH=1 -sINITIAL_MEMORY=65536000 -sMEMORY_GROWTH_GEOMETRIC_STEP=0.50 -sMODULARIZE=1 -sEXPORT_NAME=AmalgamRuntime -sENVIRONMENT=worker -sEXPORTED_RUNTIME_METHODS=cwrap,ccall,FS,setValue,getValue,UTF8ToString -sEXPORTED_FUNCTIONS=_malloc,_free,_LoadEntity,_StoreEntity,_ExecuteEntity,_ExecuteEntityJsonPtr,_DestroyEntity,_GetEntities,_SetRandomSeed,_SetJSONToLabel,_GetJSONPtrFromLabel,_SetSBFDataStoreEnabled,_IsSBFDataStoreEnabled,_GetVersionString,_SetMaxNumThreads,_GetMaxNumThreads,_GetConcurrencyTypeString,_DeleteString --preload-file /wasm/tzdata@/tzdata --preload-file /wasm/etc@/etc")
+        string(APPEND CMAKE_EXE_LINKER_FLAGS " -sINVOKE_RUN=0 -sALLOW_MEMORY_GROWTH=1 -sINITIAL_MEMORY=65536000 -sMEMORY_GROWTH_GEOMETRIC_STEP=0.50 -sMODULARIZE=1 -sEXPORT_NAME=AmalgamRuntime -sENVIRONMENT=worker -sEXPORTED_RUNTIME_METHODS=cwrap,ccall,FS,setValue,getValue,UTF8ToString -sEXPORTED_FUNCTIONS=_malloc,_free,_LoadEntity,_LoadEntityLegacy,_VerifyEntity,_StoreEntity,_ExecuteEntity,_ExecuteEntityJsonPtr,_DestroyEntity,_GetEntities,_SetRandomSeed,_SetJSONToLabel,_GetJSONPtrFromLabel,_SetSBFDataStoreEnabled,_IsSBFDataStoreEnabled,_GetVersionString,_SetMaxNumThreads,_GetMaxNumThreads,_GetConcurrencyTypeString,_DeleteString --preload-file /wasm/tzdata@/tzdata --preload-file /wasm/etc@/etc")
     endif()
 
 elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang")

--- a/src/Amalgam/Amalgam.h
+++ b/src/Amalgam/Amalgam.h
@@ -28,7 +28,7 @@ extern "C"
 	AMALGAM_EXPORT LoadEntityStatus LoadEntity(char *handle, char *path, bool persistent, bool load_contained_entities, char *write_log_filename, char *print_log_filename);
 
 	//loads the entity specified into handle
-	//TODO 19512: legacy method to support wrappers that can't call LoadEntity returning a LoadEntityStatus yet
+	//TODO 19512: deprecated - legacy method to support wrappers that can't call LoadEntity returning a LoadEntityStatus yet
 	AMALGAM_EXPORT bool LoadEntityLegacy(char *handle, char *path, bool persistent, bool load_contained_entities, char *write_log_filename, char *print_log_filename);
 
 	//verifies the entity specified by path. Uses LoadEntityStatus to return any errors and version

--- a/src/Amalgam/Amalgam.h
+++ b/src/Amalgam/Amalgam.h
@@ -27,6 +27,10 @@ extern "C"
 	//loads the entity specified into handle
 	AMALGAM_EXPORT LoadEntityStatus LoadEntity(char *handle, char *path, bool persistent, bool load_contained_entities, char *write_log_filename, char *print_log_filename);
 
+	//loads the entity specified into handle
+	//TODO 19512: legacy method to support wrappers that can't call LoadEntity returning a LoadEntityStatus yet
+	AMALGAM_EXPORT bool LoadEntityLegacy(char *handle, char *path, bool persistent, bool load_contained_entities, char *write_log_filename, char *print_log_filename);
+
 	//verifies the entity specified by path. Uses LoadEntityStatus to return any errors and version
 	AMALGAM_EXPORT LoadEntityStatus VerifyEntity(char *path);
 

--- a/src/Amalgam/AmalgamAPI.cpp
+++ b/src/Amalgam/AmalgamAPI.cpp
@@ -98,12 +98,11 @@ extern "C"
 	bool LoadEntityLegacy(char *handle, char *path, bool persistent, bool load_contained_entities, char *write_log_filename, char *print_log_filename)
 	{
 		auto status = LoadEntity(handle, path, persistent, load_contained_entities, write_log_filename, print_log_filename);
-		auto loaded = status.loaded;
 
 		delete[] status.message;
 		delete[] status.version;
 
-		return loaded;
+		return status.loaded;
 	}
 
 	LoadEntityStatus VerifyEntity(char *path)

--- a/src/Amalgam/AmalgamAPI.cpp
+++ b/src/Amalgam/AmalgamAPI.cpp
@@ -95,6 +95,11 @@ extern "C"
 		return ConvertLoadStatusToCStatus(status);
 	}
 
+	bool LoadEntityLegacy(char *handle, char *path, bool persistent, bool load_contained_entities, char *write_log_filename, char *print_log_filename)
+	{
+		return LoadEntity(handle, path, persistent, load_contained_entities, write_log_filename, print_log_filename).loaded;
+	}
+
 	LoadEntityStatus VerifyEntity(char *path)
 	{
 		std::string p(path);

--- a/src/Amalgam/AmalgamAPI.cpp
+++ b/src/Amalgam/AmalgamAPI.cpp
@@ -97,7 +97,13 @@ extern "C"
 
 	bool LoadEntityLegacy(char *handle, char *path, bool persistent, bool load_contained_entities, char *write_log_filename, char *print_log_filename)
 	{
-		return LoadEntity(handle, path, persistent, load_contained_entities, write_log_filename, print_log_filename).loaded;
+		auto status = LoadEntity(handle, path, persistent, load_contained_entities, write_log_filename, print_log_filename);
+		auto loaded = status.loaded;
+
+		delete[] status.message;
+		delete[] status.version;
+
+		return loaded;
 	}
 
 	LoadEntityStatus VerifyEntity(char *path)


### PR DESCRIPTION
Adding LoadEntityLegacy  to C API so wrappers that don't support LoadEntityStatus yet can still use new Amalgam. This method is deprecated on creation and will be removed in future releases when wrappers have been updated to use LoadEntityStatus struct.