### PR TITLE
19551: Fixes an issue where tracefile label names are in quotes

### DIFF
--- a/src/Amalgam/AmalgamTrace.cpp
+++ b/src/Amalgam/AmalgamTrace.cpp
@@ -50,7 +50,7 @@ int32_t RunAmalgamTrace(std::istream *in_stream, std::ostream *out_stream, std::
 		// perform specified operation
 		if(command == "LOAD_ENTITY")
 		{
-			std::vector<std::string> command_tokens = Platform_SplitArgString(input);
+			std::vector<std::string> command_tokens = StringManipulation::SplitArgString(input);
 			if(command_tokens.size() >= 4)
 			{
 				handle = command_tokens[0];
@@ -80,7 +80,7 @@ int32_t RunAmalgamTrace(std::istream *in_stream, std::ostream *out_stream, std::
 		}
 		else if(command == "STORE_ENTITY")
 		{
-			std::vector<std::string> command_tokens = Platform_SplitArgString(input);
+			std::vector<std::string> command_tokens = StringManipulation::SplitArgString(input);
 			if(command_tokens.size() >= 4)
 			{
 				handle = command_tokens[0];

--- a/src/Amalgam/AmalgamTrace.cpp
+++ b/src/Amalgam/AmalgamTrace.cpp
@@ -46,6 +46,7 @@ int32_t RunAmalgamTrace(std::istream *in_stream, std::ostream *out_stream, std::
 		getline(*in_stream, input, '\n');
 
 		command = StringManipulation::RemoveFirstToken(input);
+		response = "-";
 
 		// perform specified operation
 		if(command == "LOAD_ENTITY")

--- a/src/Amalgam/AmalgamTrace.cpp
+++ b/src/Amalgam/AmalgamTrace.cpp
@@ -45,7 +45,7 @@ int32_t RunAmalgamTrace(std::istream *in_stream, std::ostream *out_stream, std::
 		// read external input
 		getline(*in_stream, input, '\n');
 
-		command = StringManipulation::RemoveFirstWord(input);
+		command = StringManipulation::RemoveFirstToken(input);
 
 		// perform specified operation
 		if(command == "LOAD_ENTITY")
@@ -99,35 +99,35 @@ int32_t RunAmalgamTrace(std::istream *in_stream, std::ostream *out_stream, std::
 		}
 		else if(command == "DESTROY_ENTITY")
 		{
-			handle = StringManipulation::RemoveFirstWord(input);
+			handle = StringManipulation::RemoveFirstToken(input);
 
 			entint.DestroyEntity(handle);
 			response = SUCCESS_RESPONSE;
 		}
 		else if(command == "SET_JSON_TO_LABEL")
 		{
-			handle = StringManipulation::RemoveFirstWord(input);
-			label = StringManipulation::RemoveFirstWord(input);
+			handle = StringManipulation::RemoveFirstToken(input);
+			label = StringManipulation::RemoveFirstToken(input);
 			data = input;  // json data
 			bool result = entint.SetJSONToLabel(handle, label, data);
 			response = result ? SUCCESS_RESPONSE : FAILURE_RESPONSE;
 		}
 		else if(command == "GET_JSON_FROM_LABEL")
 		{
-			handle = StringManipulation::RemoveFirstWord(input);
-			label = StringManipulation::RemoveFirstWord(input);
+			handle = StringManipulation::RemoveFirstToken(input);
+			label = StringManipulation::RemoveFirstToken(input);
 			response = entint.GetJSONFromLabel(handle, label);
 		}
 		else if(command == "EXECUTE_ENTITY_JSON")
 		{
-			handle = StringManipulation::RemoveFirstWord(input);
-			label = StringManipulation::RemoveFirstWord(input);
+			handle = StringManipulation::RemoveFirstToken(input);
+			label = StringManipulation::RemoveFirstToken(input);
 			data = input;  // json data
 			response = entint.ExecuteEntityJSON(handle, label, data);
 		}
 		else if(command == "SET_RANDOM_SEED")
 		{
-			handle = StringManipulation::RemoveFirstWord(input);
+			handle = StringManipulation::RemoveFirstToken(input);
 			data = input;
 			bool result = entint.SetRandomSeed(handle, data);
 			response = result ? SUCCESS_RESPONSE : FAILURE_RESPONSE;

--- a/src/Amalgam/PlatformSpecific.cpp
+++ b/src/Amalgam/PlatformSpecific.cpp
@@ -16,7 +16,7 @@
 #ifdef OS_WINDOWS
 
 	// TODO 15993: disable std::wstring_convert deprecation warning: no replacement in C++17 so
-	// will require rework when we move to C++20. 
+	// will require rework when we move to C++20.
 	#pragma warning(disable: 4996)
 
 	#define NOMINMAX
@@ -74,8 +74,16 @@ std::vector<std::string> Platform_SplitArgString(const std::string &arg_string)
 			{
 				if(arg_string[cur_pos] == '"')
 				{
-					cur_pos++;
-					break;
+					if (arg_string[cur_pos - 1] == '\\')
+					{
+						//if quotation is backslashed, remove the backslash
+						cur_arg.pop_back();
+					}
+					else
+					{
+						cur_pos++;
+						break;
+					}
 				}
 
 				cur_arg.push_back(arg_string[cur_pos++]);
@@ -128,7 +136,7 @@ void Platform_SeparatePathFileExtension(const std::string &combined, std::string
 		first_slash++;  //keep the slash in the path
 		path = combined.substr(0, first_slash);
 	}
-	
+
 	//get extension
 	std::string filename = combined.substr(first_slash, combined.size() - first_slash);
 	size_t extension_position = filename.rfind('.');

--- a/src/Amalgam/PlatformSpecific.cpp
+++ b/src/Amalgam/PlatformSpecific.cpp
@@ -74,7 +74,7 @@ std::vector<std::string> Platform_SplitArgString(const std::string &arg_string)
 			{
 				if(arg_string[cur_pos] == '"')
 				{
-					if (arg_string[cur_pos - 1] == '\\')
+					if (cur_pos > 0 && arg_string[cur_pos - 1] == '\\')
 					{
 						//if quotation is backslashed, remove the backslash
 						cur_arg.pop_back();

--- a/src/Amalgam/PlatformSpecific.cpp
+++ b/src/Amalgam/PlatformSpecific.cpp
@@ -50,65 +50,6 @@
 	#include <unistd.h>
 #endif
 
-std::vector<std::string> Platform_SplitArgString(const std::string &arg_string)
-{
-	std::vector<std::string> args;
-
-	size_t cur_pos = 0;
-	while(cur_pos < arg_string.size())
-	{
-		//skip over any leading spaces
-		if(std::isspace(static_cast<unsigned char>(arg_string[cur_pos])))
-		{
-			cur_pos++;
-			continue;
-		}
-
-		std::string cur_arg;
-
-		//quotation, so go to the end of quotation
-		if(arg_string[cur_pos] == '"')
-		{
-			cur_pos++;
-			while(cur_pos < arg_string.size())
-			{
-				if(arg_string[cur_pos] == '"')
-				{
-					if (cur_pos > 0 && arg_string[cur_pos - 1] == '\\')
-					{
-						//if quotation is backslashed, remove the backslash
-						cur_arg.pop_back();
-					}
-					else
-					{
-						cur_pos++;
-						break;
-					}
-				}
-
-				cur_arg.push_back(arg_string[cur_pos++]);
-			}
-		}
-		else //not quotation, go until next whitespace
-		{
-			while(cur_pos < arg_string.size())
-			{
-				if(std::isspace(static_cast<unsigned char>(arg_string[cur_pos])))
-				{
-					cur_pos++;
-					break;
-				}
-
-				cur_arg.push_back(arg_string[cur_pos++]);
-			}
-		}
-
-		args.push_back(cur_arg);
-	}
-
-	return args;
-}
-
 void Platform_SeparatePathFileExtension(const std::string &combined, std::string &path, std::string &base_filename, std::string &extension)
 {
 	if(combined.size() == 0)

--- a/src/Amalgam/PlatformSpecific.h
+++ b/src/Amalgam/PlatformSpecific.h
@@ -1,5 +1,8 @@
 #pragma once
 
+//project headers:
+#include "StringManipulation.h"
+
 //system headers:
 #include <charconv>
 #include <chrono>
@@ -18,15 +21,15 @@
 
 #ifdef _WIN32
 	#define OS_WINDOWS
-	
+
 	#define NOMINMAX
 	#include <Windows.h>
-	
+
 	#define PLATFORM_MAIN_NO_CONSOLE int APIENTRY WinMain(HINSTANCE hCurrentInst, HINSTANCE hPreviousInst, LPSTR lpszCmdLine, int nCmdShow)
 
 	#define PLATFORM_ARGS_NO_CONSOLE			\
 		std::string arg_string(lpszCmdLine);	\
-		auto args = Platform_SplitArgString(arg_string);
+		auto args = StringManipulation::SplitArgString(arg_string);
 
 #else
 	#ifdef __linux__
@@ -41,7 +44,7 @@
 
 	//include signal to raise exception in linux
 	#include <signal.h>
-	
+
 #endif
 
 //defines __popcnt64 if it doesn't exist
@@ -165,9 +168,6 @@ inline std::pair<double, bool> Platform_StringToNumber(const std::string& s)
 #endif
 }
 
-//separates the argument string in a cross-platform manner and returns an appropriate vector of strings
-std::vector<std::string> Platform_SplitArgString(const std::string &arg_string);
-
 //Takes a string containing a combined path/filename.extension, and breaks it into each of: path, base_filename, and extension
 void Platform_SeparatePathFileExtension(const std::string &combined, std::string &path, std::string &base_filename, std::string &extension);
 
@@ -246,7 +246,7 @@ inline void Platform_Assert(bool expr, size_t line)
 #ifdef OS_MAC
 // warnings thrown on OS_MAC
 #pragma GCC diagnostic pop
-#endif 
+#endif
 
 inline void Platform_Assert(bool expr)
 {

--- a/src/Amalgam/interpreter/InterpreterDebugger.cpp
+++ b/src/Amalgam/interpreter/InterpreterDebugger.cpp
@@ -240,7 +240,7 @@ EvaluableNodeReference Interpreter::InterpretNode_DEBUG(EvaluableNode *en, bool 
 
 		std::string input;
 		std::getline(std::cin, input);
-		std::string command = StringManipulation::RemoveFirstWord(input);
+		std::string command = StringManipulation::RemoveFirstToken(input);
 
 		if(command == "help")
 		{

--- a/src/Amalgam/string/StringManipulation.cpp
+++ b/src/Amalgam/string/StringManipulation.cpp
@@ -58,7 +58,7 @@ std::string StringManipulation::RemoveFirstWord(std::string &str, bool strip_wor
 {
 	std::string first_token;
 
-	if(str.size() == 0)
+	if(str.empty())
 		return first_token;
 
 
@@ -108,7 +108,7 @@ std::string StringManipulation::RemoveFirstWord(std::string &str, bool strip_wor
 	}
 
 	//remove preceding spaces in str
-	if(str.size() > 0 && str[0] == ' ')
+	if(!str.empty() && str[0] == ' ')
 	{
 		size_t cur_pos = 1;
 		while(cur_pos < str.size() && str[cur_pos] == ' ')

--- a/src/Amalgam/string/StringManipulation.cpp
+++ b/src/Amalgam/string/StringManipulation.cpp
@@ -54,22 +54,15 @@ std::string StringManipulation::NumberToString(size_t value)
 	return std::string(&buffer[0]);
 }
 
-std::string StringManipulation::RemoveFirstWord(std::string &str)
+std::string StringManipulation::RemoveFirstToken(std::string &str)
 {
 	std::vector<std::string> arg;
-	arg = StringManipulation::SplitArgString(str, true);
+	arg = StringManipulation::SplitArgString(str, false);
 
-	if(arg.empty())
-	{
-		return "";
-	}
-	else
-	{
-		return arg[0];
-	}
+	return (arg.empty() ? "" : arg[0]);
 }
 
-std::vector<std::string> StringManipulation::SplitArgString(std::string &arg_string, bool non_greedy)
+std::vector<std::string> StringManipulation::SplitArgString(std::string &arg_string, bool greedy)
 {
 	std::vector<std::string> args;
 
@@ -122,7 +115,7 @@ std::vector<std::string> StringManipulation::SplitArgString(std::string &arg_str
 		}
 		args.push_back(cur_arg);
 
-		if(non_greedy)
+		if(!greedy)
 		{
 			arg_string = arg_string.substr(cur_pos);
 			return args;

--- a/src/Amalgam/string/StringManipulation.cpp
+++ b/src/Amalgam/string/StringManipulation.cpp
@@ -57,7 +57,6 @@ std::string StringManipulation::NumberToString(size_t value)
 std::string StringManipulation::RemoveFirstWord(std::string &str)
 {
 	std::vector<std::string> arg;
-
 	arg = StringManipulation::SplitArgString(str, true);
 
 	if(arg.empty())
@@ -83,7 +82,6 @@ std::vector<std::string> StringManipulation::SplitArgString(std::string &arg_str
 			cur_pos++;
 			continue;
 		}
-
 		std::string cur_arg;
 
 		//quotation, so go to the end of quotation
@@ -122,7 +120,6 @@ std::vector<std::string> StringManipulation::SplitArgString(std::string &arg_str
 				cur_arg.push_back(arg_string[cur_pos++]);
 			}
 		}
-
 		args.push_back(cur_arg);
 
 		if(non_greedy)

--- a/src/Amalgam/string/StringManipulation.cpp
+++ b/src/Amalgam/string/StringManipulation.cpp
@@ -64,15 +64,15 @@ std::string StringManipulation::RemoveFirstWord(std::string &str, bool strip_wor
 		size_t end_char_to_strip_idx;
 		end_char_to_strip_idx = str.find(char_to_strip, 1);
 		// the ending char_to_strip must not be escaped
-		while(str[end_char_to_strip_idx-1] == '\\') {
-			str.erase(end_char_to_strip_idx-1, 1); //remove the escape chars
-			end_char_to_strip_idx = str.find(char_to_strip, end_char_to_strip_idx+1);
+		while(str[end_char_to_strip_idx - 1] == '\\') {
+			str.erase(end_char_to_strip_idx - 1, 1); //remove the escape chars
+			end_char_to_strip_idx = str.find(char_to_strip, end_char_to_strip_idx + 1);
 		}
 
 		// chars between first and last char_to_strips make up the token
-		first_token = str.substr(1, end_char_to_strip_idx-1);
+		first_token = str.substr(1, end_char_to_strip_idx - 1);
 		// ensure remaining substring doesn't contain preceding spaces
-		str = str.substr(end_char_to_strip_idx+1);
+		str = str.substr(end_char_to_strip_idx + 1);
 		while(str[0] == ' ') {
 			str = str.substr(1); // What's the best way to do this better?
 		}

--- a/src/Amalgam/string/StringManipulation.cpp
+++ b/src/Amalgam/string/StringManipulation.cpp
@@ -1,4 +1,4 @@
-//project headers: 
+//project headers:
 #include "StringManipulation.h"
 
 #include "FastMath.h"
@@ -57,6 +57,31 @@ std::string StringManipulation::NumberToString(size_t value)
 std::string StringManipulation::RemoveFirstWord(std::string &str, bool strip_word, char char_to_strip)
 {
 	std::string first_token;
+
+	// if str is wrapped in char_to_strip, remove chars between char_to_strips (typically double quotes)
+	if(strip_word && (str[0] == char_to_strip)) {
+		size_t end_char_to_strip_idx;
+
+		end_char_to_strip_idx = str.find(char_to_strip, 1);
+		// end_char_to_strip must not be escaped
+		while(str[end_char_to_strip_idx-1] == '\\') {
+			str.erase(end_char_to_strip_idx-1, 1); //remove the escape chars
+			end_char_to_strip_idx = str.find(char_to_strip, end_char_to_strip_idx+1);
+		}
+
+		// chars between first and last char_to_strips make up the token
+		first_token = str.substr(1, end_char_to_strip_idx-1);
+
+		// make sure remaining substring doesn't have preceding spaces
+		str = str.substr(end_char_to_strip_idx+1);
+		while(str[0] == ' ') {
+			str = str.substr(1); //theres probably a much better method than this
+		}
+
+		return first_token;
+	}
+
+	// otherwise, split based on whitespace
 	size_t spacepos = str.find(' ');
 	if(spacepos == std::string::npos)
 	{
@@ -68,16 +93,6 @@ std::string StringManipulation::RemoveFirstWord(std::string &str, bool strip_wor
 		first_token = str.substr(0, spacepos);
 		str = str.substr(spacepos + 1);
 	}
-
-	if(strip_word && !first_token.empty())
-	{
-		if(first_token.back() == char_to_strip)
-			first_token.erase(first_token.size() - 1);
-
-		if(!first_token.empty() && first_token.front() == char_to_strip)
-			first_token.erase(0, 1);
-	}
-
 	return first_token;
 }
 

--- a/src/Amalgam/string/StringManipulation.cpp
+++ b/src/Amalgam/string/StringManipulation.cpp
@@ -58,12 +58,11 @@ std::string StringManipulation::RemoveFirstWord(std::string &str, bool strip_wor
 {
 	std::string first_token;
 
-	// if str is wrapped in char_to_strip, remove chars between char_to_strips (typically double quotes)
+	// if str is wrapped in char_to_strip's, remove chars between char_to_strip's (typically double quotes)
 	if(strip_word && (str[0] == char_to_strip)) {
 		size_t end_char_to_strip_idx;
-
 		end_char_to_strip_idx = str.find(char_to_strip, 1);
-		// end_char_to_strip must not be escaped
+		// the ending char_to_strip must not be escaped
 		while(str[end_char_to_strip_idx-1] == '\\') {
 			str.erase(end_char_to_strip_idx-1, 1); //remove the escape chars
 			end_char_to_strip_idx = str.find(char_to_strip, end_char_to_strip_idx+1);
@@ -71,13 +70,11 @@ std::string StringManipulation::RemoveFirstWord(std::string &str, bool strip_wor
 
 		// chars between first and last char_to_strips make up the token
 		first_token = str.substr(1, end_char_to_strip_idx-1);
-
-		// make sure remaining substring doesn't have preceding spaces
+		// ensure remaining substring doesn't contain preceding spaces
 		str = str.substr(end_char_to_strip_idx+1);
 		while(str[0] == ' ') {
-			str = str.substr(1); //theres probably a much better method than this
+			str = str.substr(1); // What's the best way to do this better?
 		}
-
 		return first_token;
 	}
 

--- a/src/Amalgam/string/StringManipulation.cpp
+++ b/src/Amalgam/string/StringManipulation.cpp
@@ -90,31 +90,34 @@ std::string StringManipulation::RemoveFirstWord(std::string &str, bool strip_wor
 
 		//update str and remove preceding spaces
 		str = str.substr(end_char_to_strip_idx + 1);
-		if(str.size() > 0 && str[0] == ' ')
-		{
-			size_t cur_pos = 1;
-			while(cur_pos < str.size() && str[cur_pos] == ' ')
-			{
-				cur_pos++;
-			}
-			str = str.substr(cur_pos);
-		}
-
-		return first_token;
-	}
-
-	//otherwise, split based on whitespace
-	size_t spacepos = str.find(' ');
-	if(spacepos == std::string::npos)
-	{
-		first_token = str;
-		str = "";
 	}
 	else
 	{
-		first_token = str.substr(0, spacepos);
-		str = str.substr(spacepos + 1);
+		//otherwise, split based on whitespace
+		size_t spacepos = str.find(' ');
+		if(spacepos == std::string::npos)
+		{
+			first_token = str;
+			str = "";
+		}
+		else
+		{
+			first_token = str.substr(0, spacepos);
+			str = str.substr(spacepos + 1);
+		}
 	}
+
+	//remove preceding spaces in str
+	if(str.size() > 0 && str[0] == ' ')
+	{
+		size_t cur_pos = 1;
+		while(cur_pos < str.size() && str[cur_pos] == ' ')
+		{
+			cur_pos++;
+		}
+		str = str.substr(cur_pos);
+	}
+
 	return first_token;
 }
 

--- a/src/Amalgam/string/StringManipulation.cpp
+++ b/src/Amalgam/string/StringManipulation.cpp
@@ -88,11 +88,18 @@ std::string StringManipulation::RemoveFirstWord(std::string &str, bool strip_wor
 		//chars between first and last char_to_strips make up the token
 		first_token = str.substr(1, end_char_to_strip_idx - 1);
 
-		//update str and remove preceding whitespace
+		//update str and remove preceding spaces
 		str = str.substr(end_char_to_strip_idx + 1);
-		while(str.size() > 0 && str[0] == ' ') {
-			str = str.substr(1); //Is there a faster way than this?
+		if(str.size() > 0 && str[0] == ' ')
+		{
+			size_t cur_pos = 1;
+			while(cur_pos < str.size() && str[cur_pos] == ' ')
+			{
+				cur_pos++;
+			}
+			str = str.substr(cur_pos);
 		}
+
 		return first_token;
 	}
 

--- a/src/Amalgam/string/StringManipulation.cpp
+++ b/src/Amalgam/string/StringManipulation.cpp
@@ -59,7 +59,8 @@ std::string StringManipulation::RemoveFirstWord(std::string &str, bool strip_wor
 	std::string first_token;
 
 	// if str is wrapped in char_to_strip's, remove chars between char_to_strip's (typically double quotes)
-	if(strip_word && (str[0] == char_to_strip)) {
+	if(strip_word && (str[0] == char_to_strip))
+	{
 		size_t end_char_to_strip_idx;
 		end_char_to_strip_idx = str.find(char_to_strip, 1);
 		// the ending char_to_strip must not be escaped

--- a/src/Amalgam/string/StringManipulation.cpp
+++ b/src/Amalgam/string/StringManipulation.cpp
@@ -54,7 +54,7 @@ std::string StringManipulation::NumberToString(size_t value)
 	return std::string(&buffer[0]);
 }
 
-std::string StringManipulation::RemoveFirstWord(std::string &str)
+std::string StringManipulation::RemoveFirstWord(std::string &str, bool strip_word, char char_to_strip)
 {
 	std::string first_token;
 	size_t spacepos = str.find(' ');
@@ -68,6 +68,16 @@ std::string StringManipulation::RemoveFirstWord(std::string &str)
 		first_token = str.substr(0, spacepos);
 		str = str.substr(spacepos + 1);
 	}
+
+	if(strip_word && !first_token.empty())
+	{
+		if(first_token.back() == char_to_strip)
+			first_token.erase(first_token.size() - 1);
+
+		if(!first_token.empty() && first_token.front() == char_to_strip)
+			first_token.erase(0, 1);
+	}
+
 	return first_token;
 }
 

--- a/src/Amalgam/string/StringManipulation.cpp
+++ b/src/Amalgam/string/StringManipulation.cpp
@@ -67,6 +67,14 @@ std::string StringManipulation::RemoveFirstWord(std::string &str, bool strip_wor
 	{
 		size_t end_char_to_strip_idx;
 		end_char_to_strip_idx = str.find(char_to_strip, 1);
+		//if no end char_to_strip return rest of str past initial char_to_strp
+		if(end_char_to_strip_idx == std::string::npos)
+		{
+			first_token = str.substr(1);
+			str = "";
+			return first_token;
+		}
+
 		//the ending char_to_strip must not be escaped
 		if(end_char_to_strip_idx != 0)
 		{

--- a/src/Amalgam/string/StringManipulation.cpp
+++ b/src/Amalgam/string/StringManipulation.cpp
@@ -58,28 +58,37 @@ std::string StringManipulation::RemoveFirstWord(std::string &str, bool strip_wor
 {
 	std::string first_token;
 
-	// if str is wrapped in char_to_strip's, remove chars between char_to_strip's (typically double quotes)
+	if(str.size() == 0)
+		return first_token;
+
+
+	//if str is wrapped in char_to_strip's, remove chars between char_to_strip's (typically double quotes)
 	if(strip_word && (str[0] == char_to_strip))
 	{
 		size_t end_char_to_strip_idx;
 		end_char_to_strip_idx = str.find(char_to_strip, 1);
-		// the ending char_to_strip must not be escaped
-		while(str[end_char_to_strip_idx - 1] == '\\') {
-			str.erase(end_char_to_strip_idx - 1, 1); //remove the escape chars
-			end_char_to_strip_idx = str.find(char_to_strip, end_char_to_strip_idx + 1);
+		//the ending char_to_strip must not be escaped
+		if(end_char_to_strip_idx != 0)
+		{
+			while(str[end_char_to_strip_idx - 1] == '\\')
+			{
+				str.erase(end_char_to_strip_idx - 1, 1); //remove the escape chars
+				end_char_to_strip_idx = str.find(char_to_strip, end_char_to_strip_idx + 1);
+			}
 		}
 
-		// chars between first and last char_to_strips make up the token
+		//chars between first and last char_to_strips make up the token
 		first_token = str.substr(1, end_char_to_strip_idx - 1);
-		// ensure remaining substring doesn't contain preceding spaces
+
+		//update str and remove preceding whitespace
 		str = str.substr(end_char_to_strip_idx + 1);
-		while(str[0] == ' ') {
-			str = str.substr(1); // What's the best way to do this better?
+		while(str.size() > 0 && str[0] == ' ') {
+			str = str.substr(1); //Is there a faster way than this?
 		}
 		return first_token;
 	}
 
-	// otherwise, split based on whitespace
+	//otherwise, split based on whitespace
 	size_t spacepos = str.find(' ');
 	if(spacepos == std::string::npos)
 	{

--- a/src/Amalgam/string/StringManipulation.h
+++ b/src/Amalgam/string/StringManipulation.h
@@ -14,10 +14,15 @@ namespace StringManipulation
 
 	//removes the first word from str and return the removed word
 	//if strip_word true, remove char_to_strip from beginning and end of returned word
-	std::string RemoveFirstWord(std::string &str, bool strip_word = true, char char_to_strip = '\"');
+	std::string RemoveFirstWord(std::string &str);
 
 	//splits a string by given delimiter
 	std::vector<std::string> Split(std::string &s, char delim = ' ');
+
+	//separates the argument string in a cross-platform manner and returns an appropriate vector of strings
+	//if non_greedy is true, the returned vector only contains a single string, and arg_string is modified
+	//to only contain the portion of the string after the removed section
+	std::vector<std::string> SplitArgString(std::string &arg_string, bool non_greedy = false);
 
 	//returns true if the character in the string s starting at position is whitespace
 	inline bool IsUtf8Whitespace(std::string &s, size_t position)
@@ -366,7 +371,7 @@ namespace StringManipulation
 			return 10 + c - 'a';
 		if(c >= 'A' && c <= 'F')
 			return 10 + c - 'A';
-	
+
 		return 0;
 	}
 

--- a/src/Amalgam/string/StringManipulation.h
+++ b/src/Amalgam/string/StringManipulation.h
@@ -13,9 +13,11 @@ namespace StringManipulation
 	std::string NumberToString(size_t value);
 
 	//removes the first word from str and return the removed word
-	std::string RemoveFirstWord(std::string &str);
+	//if strip_word true, remove char_to_strip from beginning and end of returned word
+	std::string RemoveFirstWord(std::string &str, bool strip_word = true, char char_to_strip = '\"');
 
-	std::vector<std::string> Split(std::string &s, char delim);
+	//splits a string by given delimiter
+	std::vector<std::string> Split(std::string &s, char delim = ' ');
 
 	//returns true if the character in the string s starting at position is whitespace
 	inline bool IsUtf8Whitespace(std::string &s, size_t position)

--- a/src/Amalgam/string/StringManipulation.h
+++ b/src/Amalgam/string/StringManipulation.h
@@ -13,16 +13,15 @@ namespace StringManipulation
 	std::string NumberToString(size_t value);
 
 	//removes the first word from str and return the removed word
-	//if strip_word true, remove char_to_strip from beginning and end of returned word
-	std::string RemoveFirstWord(std::string &str);
+	std::string RemoveFirstToken(std::string &str);
 
 	//splits a string by given delimiter
 	std::vector<std::string> Split(std::string &s, char delim = ' ');
 
-	//separates the argument string in a cross-platform manner and returns an appropriate vector of strings
+	//separates the argument string and returns an appropriate vector of strings
 	//if non_greedy is true, the returned vector only contains a single string, and arg_string is modified
 	//to only contain the portion of the string after the removed section
-	std::vector<std::string> SplitArgString(std::string &arg_string, bool non_greedy = false);
+	std::vector<std::string> SplitArgString(std::string &arg_string, bool greedy = true);
 
 	//returns true if the character in the string s starting at position is whitespace
 	inline bool IsUtf8Whitespace(std::string &s, size_t position)

--- a/src/Amalgam/string/StringManipulation.h
+++ b/src/Amalgam/string/StringManipulation.h
@@ -12,14 +12,15 @@ namespace StringManipulation
 	std::string NumberToString(double value);
 	std::string NumberToString(size_t value);
 
-	//removes the first word from str and return the removed word
+	//removes the first token from str and return the removed token
 	std::string RemoveFirstToken(std::string &str);
 
 	//splits a string by given delimiter
 	std::vector<std::string> Split(std::string &s, char delim = ' ');
 
 	//separates the argument string and returns an appropriate vector of strings
-	//if non_greedy is true, the returned vector only contains a single string, and arg_string is modified
+	//if greedy is true, the returned vector contains the full list of arguments and arg_string is unmodified
+	//if greedy is false, the returned vector only contains a single string, and arg_string is modified
 	//to only contain the portion of the string after the removed section
 	std::vector<std::string> SplitArgString(std::string &arg_string, bool greedy = true);
 


### PR DESCRIPTION
Running tracefiles with label names surrounded in quotes was not executing the labels correctly. 

My change here moves and renames `Platform_SplitArgString` to `StringManipulation::SplitArgString` (and moves it from PlatformSpecific.h/cpp to StringManipulation.h/cpp)

Additionally, a boolean flag is added to this method named `greedy`. As the name suggests, if `greedy` is True, then the method returns the full vector of args. If it is False, then a vector with only the first arg is returned and the argument string is modified to have that first word cut out.

Then, `RemoveFirstWord` is renamed to `RemoveFirstToken` and modified to use this new modified version of `SplitArgString` with the `greedy` flag set to False to remove the first word, then returns an empty string if no string is returned.
