### PR TITLE
19723: Handle possible errors from create_directory

### DIFF
--- a/src/Amalgam/AssetManager.cpp
+++ b/src/Amalgam/AssetManager.cpp
@@ -410,7 +410,6 @@ void AssetManager::CreateEntity(Entity *entity)
 	std::string traversal_path = "";
 	std::string escaped_entity_id = FilenameEscapeProcessor::SafeEscapeFilename(entity->GetId());
 	std::string id_suffix = "/" + escaped_entity_id + "." + defaultEntityExtension;
-	std::error_code ec;
 	while(cur != nullptr)
 	{
 		const auto &pe = persistentEntities.find(cur);
@@ -419,6 +418,7 @@ void AssetManager::CreateEntity(Entity *entity)
 			Platform_SeparatePathFileExtension(pe->second, slice_path, filename, extension);
 			//create contained entity directory in case it doesn't currently exist
 			std::string new_path = slice_path + filename + traversal_path;
+			std::error_code ec;
 			bool created_successfully = std::filesystem::create_directory(new_path, ec);
 
 			if(ec || !created_successfully)

--- a/src/Amalgam/AssetManager.cpp
+++ b/src/Amalgam/AssetManager.cpp
@@ -421,14 +421,18 @@ void AssetManager::CreateEntity(Entity *entity)
 			std::error_code ec;
 			bool created_successfully = std::filesystem::create_directory(new_path, ec);
 
-			if(ec || !created_successfully)
+			if(!ec && created_successfully)
+			{
+				// std::cerr << "Could not create directory: " << new_path << std::endl;
+				// continue;
+				new_path += id_suffix;
+				StoreEntityToResourcePath(entity, new_path, extension, false, true, false, true, false);
+			}
+			else
 			{
 				std::cerr << "Could not create directory: " << new_path << std::endl;
-				continue;
 			}
 
-			new_path += id_suffix;
-			StoreEntityToResourcePath(entity, new_path, extension, false, true, false, true, false);
 		}
 
 		//don't need to continue and allocate extra traversal path if already at outermost entity

--- a/src/Amalgam/AssetManager.cpp
+++ b/src/Amalgam/AssetManager.cpp
@@ -423,8 +423,6 @@ void AssetManager::CreateEntity(Entity *entity)
 
 			if(!ec && created_successfully)
 			{
-				// std::cerr << "Could not create directory: " << new_path << std::endl;
-				// continue;
 				new_path += id_suffix;
 				StoreEntityToResourcePath(entity, new_path, extension, false, true, false, true, false);
 			}

--- a/src/Amalgam/AssetManager.cpp
+++ b/src/Amalgam/AssetManager.cpp
@@ -391,17 +391,17 @@ void AssetManager::UpdateEntity(Entity *entity)
 	}
 }
 
-bool AssetManager::CreateEntity(Entity *entity)
+void AssetManager::CreateEntity(Entity *entity)
 {
 	if(entity == nullptr)
-		return false;
+		return;
 
 #ifdef MULTITHREAD_INTERFACE
 	Concurrency::ReadLock lock(persistentEntitiesMutex);
 #endif
 	//early out if no persistent entities
 	if(persistentEntities.size() == 0)
-		return false;
+		return;
 
 	Entity *cur = entity->GetContainer();
 	std::string slice_path;
@@ -422,7 +422,10 @@ bool AssetManager::CreateEntity(Entity *entity)
 			bool created_successfully = std::filesystem::create_directory(new_path, ec);
 
 			if(ec || !created_successfully)
-				return false;
+			{
+				std::cerr << "Could not create directory: " << new_path << std::endl;
+				continue;
+			}
 
 			new_path += id_suffix;
 			StoreEntityToResourcePath(entity, new_path, extension, false, true, false, true, false);
@@ -437,7 +440,6 @@ bool AssetManager::CreateEntity(Entity *entity)
 		traversal_path = "/" + escaped_entity_id + traversal_path;
 		cur = cur_container;
 	}
-	return true;
 }
 
 void AssetManager::SetRootPermission(Entity *entity, bool permission)

--- a/src/Amalgam/AssetManager.h
+++ b/src/Amalgam/AssetManager.h
@@ -69,7 +69,7 @@ public:
 
 	//Indicates that the entity has been written to or updated, and so if the asset is persistent, the persistent copy should be updated
 	void UpdateEntity(Entity *entity);
-	bool CreateEntity(Entity *entity);
+	void CreateEntity(Entity *entity);
 	inline void DestroyEntity(Entity *entity)
 	{
 	#ifdef MULTITHREAD_INTERFACE

--- a/src/Amalgam/AssetManager.h
+++ b/src/Amalgam/AssetManager.h
@@ -69,7 +69,7 @@ public:
 
 	//Indicates that the entity has been written to or updated, and so if the asset is persistent, the persistent copy should be updated
 	void UpdateEntity(Entity *entity);
-	void CreateEntity(Entity *entity);
+	bool CreateEntity(Entity *entity);
 	inline void DestroyEntity(Entity *entity)
 	{
 	#ifdef MULTITHREAD_INTERFACE
@@ -77,7 +77,7 @@ public:
 	#endif
 
 		RemoveRootPermissions(entity);
-		
+
 		if(persistentEntities.size() > 0)
 			DestroyPersistentEntity(entity);
 	}

--- a/src/Amalgam/entity/Entity.cpp
+++ b/src/Amalgam/entity/Entity.cpp
@@ -481,7 +481,7 @@ EvaluableNodeReference Entity::Execute(ExecutionCycleCount max_num_steps, Execut
 #ifdef MULTITHREAD_SUPPORT
 	interpreter.memoryModificationLock.unlock();
 #endif
-		
+
 	return retval;
 }
 
@@ -529,10 +529,10 @@ size_t Entity::GetDeepSizeInNodes()
 size_t Entity::GetEstimatedReservedDeepSizeInBytes()
 {
 	size_t total_size = evaluableNodeManager.GetEstimatedTotalReservedSizeInBytes();
-	
+
 	for(auto entity : GetContainedEntities())
 		total_size += entity->GetEstimatedReservedDeepSizeInBytes();
-	
+
 	return total_size;
 }
 
@@ -572,7 +572,7 @@ StringInternPool::StringID Entity::AddContainedEntity(Entity *t, StringInternPoo
 	size_t t_index = contained_entities.size();
 
 	StringInternPool::StringID previous_t_sid = t->idStringId;
-	
+
 	//autoassign an ID if not specified
 	if(id_sid == StringInternPool::NOT_A_STRING_ID)
 	{
@@ -583,7 +583,7 @@ StringInternPool::StringID Entity::AddContainedEntity(Entity *t, StringInternPoo
 			new_id = "_" + EvaluableNode::NumberToString(static_cast<size_t>(randomStream.RandUInt32()));
 
 			t->idStringId = string_intern_pool.CreateStringReference(new_id);
-			
+
 			//if not currently in use, then use it and stop searching
 			if(id_to_index_lookup.insert(std::make_pair(t->idStringId, t_index)).second == true)
 				break;
@@ -617,7 +617,9 @@ StringInternPool::StringID Entity::AddContainedEntity(Entity *t, StringInternPoo
 	{
 		for(auto &wl : *write_listeners)
 			wl->LogCreateEntity(t);
-		asset_manager.CreateEntity(t);
+		bool created_successfully = asset_manager.CreateEntity(t);
+		if(!created_successfully)
+			return StringInternPool::NOT_A_STRING_ID;
 	}
 
 	return t->idStringId;
@@ -684,7 +686,9 @@ StringInternPool::StringID Entity::AddContainedEntity(Entity *t, std::string id_
 	{
 		for(auto &wl : *write_listeners)
 			wl->LogCreateEntity(t);
-		asset_manager.CreateEntity(t);
+		bool created_successfully = asset_manager.CreateEntity(t);
+		if(!created_successfully)
+			return StringInternPool::NOT_A_STRING_ID;
 	}
 
 	return t->idStringId;
@@ -707,7 +711,7 @@ void Entity::RemoveContainedEntity(StringInternPool::StringID id, std::vector<En
 	size_t index_to_remove = id_to_index_it_to_remove->second;
 	size_t index_to_replace = contained_entities.size() - 1;
 	Entity *entity_to_remove = contained_entities[index_to_remove];
-		
+
 	//record the entity as being deleted
 	if(write_listeners != nullptr)
 	{
@@ -852,7 +856,7 @@ void Entity::SetRoot(EvaluableNode *_code, bool allocated_with_entity_enm, Evalu
 		evaluableNodeManager.SetRootNode(evaluableNodeManager.AllocNode(ENT_NULL));
 	}
 	else if(allocated_with_entity_enm && metadata_modifier == EvaluableNodeManager::ENMM_NO_CHANGE)
-	{		
+	{
 		evaluableNodeManager.SetRootNode(_code);
 	}
 	else

--- a/src/Amalgam/entity/Entity.cpp
+++ b/src/Amalgam/entity/Entity.cpp
@@ -481,7 +481,7 @@ EvaluableNodeReference Entity::Execute(ExecutionCycleCount max_num_steps, Execut
 #ifdef MULTITHREAD_SUPPORT
 	interpreter.memoryModificationLock.unlock();
 #endif
-
+		
 	return retval;
 }
 
@@ -529,10 +529,10 @@ size_t Entity::GetDeepSizeInNodes()
 size_t Entity::GetEstimatedReservedDeepSizeInBytes()
 {
 	size_t total_size = evaluableNodeManager.GetEstimatedTotalReservedSizeInBytes();
-
+	
 	for(auto entity : GetContainedEntities())
 		total_size += entity->GetEstimatedReservedDeepSizeInBytes();
-
+	
 	return total_size;
 }
 
@@ -572,7 +572,7 @@ StringInternPool::StringID Entity::AddContainedEntity(Entity *t, StringInternPoo
 	size_t t_index = contained_entities.size();
 
 	StringInternPool::StringID previous_t_sid = t->idStringId;
-
+	
 	//autoassign an ID if not specified
 	if(id_sid == StringInternPool::NOT_A_STRING_ID)
 	{
@@ -583,7 +583,7 @@ StringInternPool::StringID Entity::AddContainedEntity(Entity *t, StringInternPoo
 			new_id = "_" + EvaluableNode::NumberToString(static_cast<size_t>(randomStream.RandUInt32()));
 
 			t->idStringId = string_intern_pool.CreateStringReference(new_id);
-
+			
 			//if not currently in use, then use it and stop searching
 			if(id_to_index_lookup.insert(std::make_pair(t->idStringId, t_index)).second == true)
 				break;
@@ -617,9 +617,7 @@ StringInternPool::StringID Entity::AddContainedEntity(Entity *t, StringInternPoo
 	{
 		for(auto &wl : *write_listeners)
 			wl->LogCreateEntity(t);
-		bool created_successfully = asset_manager.CreateEntity(t);
-		if(!created_successfully)
-			return StringInternPool::NOT_A_STRING_ID;
+		asset_manager.CreateEntity(t);
 	}
 
 	return t->idStringId;
@@ -686,9 +684,7 @@ StringInternPool::StringID Entity::AddContainedEntity(Entity *t, std::string id_
 	{
 		for(auto &wl : *write_listeners)
 			wl->LogCreateEntity(t);
-		bool created_successfully = asset_manager.CreateEntity(t);
-		if(!created_successfully)
-			return StringInternPool::NOT_A_STRING_ID;
+		asset_manager.CreateEntity(t);
 	}
 
 	return t->idStringId;
@@ -711,7 +707,7 @@ void Entity::RemoveContainedEntity(StringInternPool::StringID id, std::vector<En
 	size_t index_to_remove = id_to_index_it_to_remove->second;
 	size_t index_to_replace = contained_entities.size() - 1;
 	Entity *entity_to_remove = contained_entities[index_to_remove];
-
+		
 	//record the entity as being deleted
 	if(write_listeners != nullptr)
 	{
@@ -856,7 +852,7 @@ void Entity::SetRoot(EvaluableNode *_code, bool allocated_with_entity_enm, Evalu
 		evaluableNodeManager.SetRootNode(evaluableNodeManager.AllocNode(ENT_NULL));
 	}
 	else if(allocated_with_entity_enm && metadata_modifier == EvaluableNodeManager::ENMM_NO_CHANGE)
-	{
+	{		
 		evaluableNodeManager.SetRootNode(_code);
 	}
 	else


### PR DESCRIPTION
Following a recent change to add error handling on a call to `std::filesystem::create_directories`, I am attempting to add a similar check to a call to `std::filesystem::create_directory`.

