### PR TITLE
17481: Adds retry strategy to ninja installation on Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -166,7 +166,18 @@ jobs:
       run: ./build/powershell/Download-Tzdata.ps1
 
     - name: Install build dependencies
-      run: choco upgrade ninja
+      run: |
+        max_retries=2
+        count=0
+        until choco upgrade ninja; do
+          ((count++))
+          echo "Failed to install Ninja (attempt $count of $max_retries)"
+          if [ "$count" -ge "$max_retries" ]; then
+            echo "Reached maximum number of retries"
+            exit 1
+          fi
+          sleep 5
+        done
 
     - name: CMake Configure
       run: AMALGAM_BUILD_VERSION=${{ inputs.version }} cmake --preset $PRESET

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -176,7 +176,6 @@ jobs:
             echo "Reached maximum number of retries"
             exit 1
           fi
-          sleep 5
         done
 
     - name: CMake Configure


### PR DESCRIPTION
During a build, this will attempt to install Ninja with up to two additional attempts if it fails. Chocolatey frequently fails to install Ninja during our nightly tests.