### PR TITLE
20712: Fixes bug where CMake build type wasn't recognized, sets default stack size on MacOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,22 @@ include(global_settings)
 include(version)
 include(global_compiler_flags)
 
+# Enforce correct CMAKE_BUILD_TYPE value
+if(NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Choose the type of build (Debug or Release)" FORCE)
+endif()
+
+if(CMAKE_BUILD_TYPE STREQUAL "Release")
+    message(STATUS "Release build: ${CMAKE_CXX_FLAGS_RELEASE}")
+    if(CMAKE_CXX_FLAGS_RELEASE MATCHES "-g")
+        message(FATAL_ERROR "Release build should not include debug symbols (-g)")
+    endif()
+elseif(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    message(STATUS "Debug build: ${CMAKE_CXX_FLAGS_DEBUG}")
+else()
+    message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")
+endif()
+
 # Print useful info from global settings/flags/env
 message(STATUS "Amalgam version (orig)       : '${AMALGAM_VERSION_ORIG}'")
 message(STATUS "Amalgam version (clean)      : '${AMALGAM_VERSION}'")

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -90,7 +90,7 @@
       "hidden": true,
       "description": "Sets debug build type",
       "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "debug"
+        "CMAKE_BUILD_TYPE": "Debug"
       }
     },
     {
@@ -98,7 +98,7 @@
       "hidden": true,
       "description": "Sets release build type",
       "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "release"
+        "CMAKE_BUILD_TYPE": "Release"
       }
     },
 

--- a/build/cmake/global_compiler_flags.cmake
+++ b/build/cmake/global_compiler_flags.cmake
@@ -3,7 +3,9 @@
 #
 
 # TODO 15993: do we need this? Can it be smaller? How do we set it on all platforms?
-set(DEFAULT_STACK_SIZE 67108864)
+set(DEFAULT_STACK_SIZE_WIN 67108864)
+
+set(DEFAULT_STACK_SIZE_MACOS 0x4000000)
 
 set(IS_MSVC False)
 set(IS_GCC False)
@@ -21,7 +23,7 @@ if(MSVC)
 
     # Common flags:
     string(APPEND CMAKE_CXX_FLAGS " /nologo /W3 /WX /MP /GS /TP /FC /fp:precise /Zc:wchar_t /Zc:forScope /Zc:inline /analyze-")
-    string(APPEND CMAKE_EXE_LINKER_FLAGS " /STACK:${DEFAULT_STACK_SIZE}")
+    string(APPEND CMAKE_EXE_LINKER_FLAGS " /STACK:${DEFAULT_STACK_SIZE_WIN}")
 
     # Debug flags:
     string(APPEND CMAKE_CXX_FLAGS_DEBUG " /JMC")
@@ -121,6 +123,11 @@ if(IS_UNIX)
     if(NOT IS_WASM)
         string(APPEND CMAKE_CXX_FLAGS " -march=${ARCH_VERSION}")
     endif()
+endif()
+
+# Set stack size for macOS
+if(IS_MACOS)
+    string(APPEND CMAKE_EXE_LINKER_FLAGS " -Wl,-stack_size,${DEFAULT_STACK_SIZE_MACOS}")
 endif()
 
 # MSVC only:


### PR DESCRIPTION
* Fixes an issue where build configurations weren't being recognized by CMake, so applicable compiler flags (e.g., `-g`) were not being applied
* Sets the default stack size on MacOS to the maximum possible amount (512mb) [currently only set on Windows, not possible on Linux]