### PR TITLE
20765: Turns off several exceptions in universal initialization

### DIFF
--- a/src/Amalgam/PlatformSpecific.cpp
+++ b/src/Amalgam/PlatformSpecific.cpp
@@ -7,11 +7,23 @@
 #include <algorithm>
 #include <array>
 #include <cctype>
+#include <cfenv>
 #include <codecvt>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <fstream>
+
+//perform universal initialization
+class PlatformSpecificStartup
+{
+public:
+    PlatformSpecificStartup()
+    {
+	    std::feclearexcept(FE_ALL_EXCEPT);
+    }
+};
+PlatformSpecificStartup _platform_specific_startup;
 
 #ifdef OS_WINDOWS
 


### PR DESCRIPTION
Disables several exceptions that are being suppressed by Python up the stack but are affecting the Evolver: FE_INEXACT, FE_DIVBYZERO, FE_UNDERFLOW, FE_OVERFLOW, and FE_INVALID.