### PR TITLE
21092: Fixes an issue with (call_sandboxed) where the number of active threads isn't properly protected/edited

### DIFF
--- a/src/Amalgam/ThreadPool.cpp
+++ b/src/Amalgam/ThreadPool.cpp
@@ -66,12 +66,12 @@ void ThreadPool::AddNewThread()
 	threads.emplace_back(
 		[this]
 		{
+			std::unique_lock<std::mutex> lock(threadsMutex);
+
 			//count this thread as active during startup
 			//this is important, as the inner loop assumes the default state of the thread is to count itself
 			//so the number of threads doesn't change when switching between a completed task and a new one
 			numActiveThreads++;
-
-			std::unique_lock<std::mutex> lock(threadsMutex);
 
 			//infinite loop waiting for work
 			for(;;)


### PR DESCRIPTION
Moving the lock of the `threadsMutex` just before `numActiveThreads` is incremented.