### PR TITLE
21562: Add generic wasm64 build preset

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -263,6 +263,26 @@
       }
     },
     {
+      "name": "wasm64-release",
+      "description": "emcc for wasm64 (release)",
+      "inherits": [ "base", "wasm64", "release", "emcc" ],
+      "cacheVariables": {
+        "CMAKE_OSX_ARCHITECTURES": "",
+        "CMAKE_CXX_COMPILER_TARGET": "wasm64-unknown-emscripten",
+        "CMAKE_TRY_COMPILE_TARGET_TYPE": "STATIC_LIBRARY"
+      }
+    },
+    {
+      "name": "wasm64-debug",
+      "description": "emcc for wasm64 (debug)",
+      "inherits": [ "base", "wasm64", "debug", "emcc" ],
+      "cacheVariables": {
+        "CMAKE_OSX_ARCHITECTURES": "",
+        "CMAKE_CXX_COMPILER_TARGET": "wasm64-unknown-emscripten",
+        "CMAKE_TRY_COMPILE_TARGET_TYPE": "STATIC_LIBRARY"
+      }
+    },
+    {
       "name": "wasm64-debug-linux",
       "description": "emcc for wasm64 (debug) for linux",
       "inherits": [ "base", "linux", "wasm64", "debug", "emcc" ],
@@ -370,6 +390,16 @@
       "name": "wasm64-release-linux",
       "configurePreset": "wasm64-release-linux",
       "description": "linux wasm64 release build"
+    },
+    {
+      "name": "wasm64-release",
+      "configurePreset": "wasm64-release",
+      "description": "wasm64 release build"
+    },
+    {
+      "name": "wasm64-debug",
+      "configurePreset": "wasm64-debug",
+      "description": "wasm64 debug build"
     },
     {
       "name": "amd64-debug-macos",

--- a/build/cmake/create_tests.cmake
+++ b/build/cmake/create_tests.cmake
@@ -8,7 +8,10 @@ enable_testing()
 set(CMAKE_CTEST_ARGUMENTS "-j" "--schedule-random" "--output-on-failure" "--extra-verbose" "--output-log" "${CMAKE_SOURCE_DIR}/out/test/all_tests.log")
 
 # Not all tests can be run on all platforms:
-if(IS_MACOS)
+if(IS_WASM)
+    # No tests to run for WASM
+    list(PREPEND CMAKE_CTEST_ARGUMENTS "-LE" ".*")
+elseif(IS_MACOS)
     if(IS_ARM64)
         # Can't run cross compiled arm64 binaries on macos amd64 hosts
         list(PREPEND CMAKE_CTEST_ARGUMENTS "-LE" ".*")
@@ -16,9 +19,6 @@ if(IS_MACOS)
         # Can't run advanced intrinsic builds on macos amd64 build machines
         list(PREPEND CMAKE_CTEST_ARGUMENTS "-LE" "advanced_intrinsics")
     endif()
-elseif(IS_WASM)
-    # No tests to run for WASM
-    list(PREPEND CMAKE_CTEST_ARGUMENTS "-LE" ".*")
 else()
     list(PREPEND CMAKE_CTEST_ARGUMENTS "-L" "smoke_test")
 endif()

--- a/build/cmake/global_compiler_flags.cmake
+++ b/build/cmake/global_compiler_flags.cmake
@@ -127,7 +127,11 @@ endif()
 
 # Set stack size for macOS
 if(IS_MACOS)
-    string(APPEND CMAKE_EXE_LINKER_FLAGS " -Wl,-stack_size,${DEFAULT_STACK_SIZE_MACOS}")
+    if(IS_WASM)
+        set(CMAKE_CXX_LINK_FLAGS "")
+    else()
+        string(APPEND CMAKE_EXE_LINKER_FLAGS " -Wl,-stack_size,${DEFAULT_STACK_SIZE_MACOS}")
+    endif()
 endif()
 
 # MSVC only:


### PR DESCRIPTION
- Adds new build target for wasm64 that is intended to be platform independent
- Corrected issues when building on MacOS