### PR TITLE
22209: Update Amalgam Build to use GLIBC2_28 container

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -337,7 +337,7 @@ jobs:
       - name: Extract Amalgam
         run: |
           mkdir ./amalgam
-          tar -xvf ./amalgam-${{ inputs.version }}-linux-amd64-228.tar.gz -C ./amalgam
+          tar -xvf ./amalgam-${{ inputs.version }}-linux-amd64.tar.gz -C ./amalgam
 
       - name: Smoke test
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,6 +90,69 @@ jobs:
           path: ./out/package/amalgam-*.tar.gz
           if-no-files-found: error
 
+  build-linux-228:
+    runs-on: ubuntu-20.04
+    container:
+      image: ghcr.io/howsoai/amalgam-build-container-linux-228:2.0.9
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ github.token }}
+    strategy:
+      matrix:
+        preset:
+          - arch: amd64
+            platform: linux
+            type: release
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set build preset
+        run: |
+          PRESET=$(echo ${{ matrix.preset.arch }}-${{ matrix.preset.type }}-${{ matrix.preset.platform }}-228)
+          echo "PRESET=$(echo $PRESET)" >> $GITHUB_ENV
+          echo "Build preset: $PRESET"
+          # Print glibc version
+          ldd --version
+
+      - name: CMake Configure
+        run: AMALGAM_BUILD_VERSION=${{ inputs.version }} cmake --preset $PRESET
+
+      - name: CMake Build
+        run: cmake --build --preset $PRESET --
+
+      - name: CMake Test
+        run: cmake --build --preset $PRESET --target test
+
+      - name: Print/copy out.txt
+        if: always()
+        continue-on-error: true
+        run: |
+          tail -n 20 src/Amalgam/out.txt
+          cp src/Amalgam/out.txt ./out/test/
+          
+      - name: Upload Test Results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-${{ matrix.preset.type }}-${{ matrix.preset.platform }}-${{ matrix.preset.arch }}-228
+          path: ./out/test/*
+
+      - name: CMake Install
+        run: cmake --build --preset $PRESET --target install
+
+      - name: CMake Package
+        run: cmake --build --preset $PRESET --target package
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: amalgam-${{ inputs.version }}-${{ matrix.preset.type }}-${{ matrix.preset.platform }}-${{ matrix.preset.arch }}-228
+          path: ./out/package/amalgam-*.tar.gz
+          if-no-files-found: error
+
   build-macos:
     runs-on: macos-13
     strategy:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -320,6 +320,33 @@ jobs:
             echo -n "$f: " && "./$f" --version
           done
 
+  smoke-test-linux-amd64-228:
+    needs: ["build-linux-228"]
+    runs-on: ubuntu-24.04
+    container:
+      image: ghcr.io/howsoai/amalgam-build-container-linux-228:2.0.9
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ github.token }}
+    steps:
+      - name: Download Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: amalgam-${{ inputs.version }}-release-linux-amd64-228
+
+      - name: Extract Amalgam
+        run: |
+          mkdir ./amalgam
+          tar -xvf ./amalgam-${{ inputs.version }}-linux-amd64-228.tar.gz -C ./amalgam
+
+      - name: Smoke test
+        run: |
+          set -e
+          cd ./amalgam/bin
+          for f in *; do
+            echo -n "$f: " && "./$f" --version
+          done
+
   smoke-test-linux-arm64:
     needs: ['build-linux']
     runs-on: ubuntu-latest
@@ -522,6 +549,7 @@ jobs:
     secrets: inherit
     needs:
       - smoke-test-linux-amd64
+      - smoke-test-linux-amd64-228
       - smoke-test-linux-arm64
       - smoke-test-linux-arm64_8a
       - smoke-test-macos-amd64
@@ -536,6 +564,7 @@ jobs:
     if: inputs.build-type == 'release'
     needs:
       - smoke-test-linux-amd64
+      - smoke-test-linux-amd64-228
       - smoke-test-linux-arm64
       - smoke-test-linux-arm64_8a
       - smoke-test-macos-amd64

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,7 @@ message(STATUS "Amalgam version full escaped : '${AMALGAM_VERSION_FULL_ESCAPED}'
 message(STATUS "Use object libs              : ${USE_OBJECT_LIBS}")
 message(STATUS "System name                  : ${CMAKE_SYSTEM_NAME}")
 message(STATUS "OS                           : ${OS}")
+message(STATUS "OS GLIBC Version             : ${GLIBC_VERSION}")
 message(STATUS "Target system version        : ${CMAKE_SYSTEM_VERSION}")
 if(IS_VISUALSTUDIO)
 message(STATUS "Target system version - VS   : ${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION}")

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -123,6 +123,14 @@
       }
     },
     {
+      "name": "g++",
+      "hidden": true,
+      "description": "Sets g++ compiler",
+      "cacheVariables": {
+        "CMAKE_CXX_COMPILER": "g++"
+      }
+    },
+    {
       "name": "gcc",
       "hidden": true,
       "description": "Sets gcc compiler",
@@ -201,7 +209,26 @@
         "rhs": "Windows"
       }
     },
-
+    {
+      "name": "amd64-debug-linux-228",
+      "description": "g++ for amd64 (debug) for linux",
+      "inherits": [ "base", "linux", "amd64", "debug", "g++" ],
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Linux"
+      }
+    },
+    {
+      "name": "amd64-release-linux-228",
+      "description": "g++ for amd64 (release) for linux",
+      "inherits": [ "base", "linux", "amd64", "release", "g++" ],
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Linux"
+      }
+    },
     {
       "name": "amd64-debug-linux",
       "description": "gcc for amd64 (debug) for linux",
@@ -347,6 +374,16 @@
       "description": "linux amd64 release build"
     },
     {
+      "name": "amd64-debug-linux-228",
+      "configurePreset": "amd64-debug-linux-228",
+      "description": "linux glibc 2.28 amd64 debug build"
+    },
+    {
+      "name": "amd64-release-linux-228",
+      "configurePreset": "amd64-release-linux-228",
+      "description": "linux glibc 2.28 amd64 release build"
+    },
+    {
       "name": "arm64-debug-linux",
       "configurePreset": "arm64-debug-linux",
       "description": "linux arm64 debug build"
@@ -424,6 +461,18 @@
       "description": "linux amd64 debug tests",
       "inherits": "base",
       "configurePreset": "amd64-debug-linux"
+    },
+    {
+      "name": "amd64-release-linux-228",
+      "description": "linux glibc 2.28 amd64 release tests",
+      "inherits": "base",
+      "configurePreset": "amd64-release-linux-228"
+    },
+    {
+      "name": "amd64-debug-linux-228",
+      "description": "linux glibc 2.28 amd64 debug tests",
+      "inherits": "base",
+      "configurePreset": "amd64-debug-linux-228"
     },
     {
       "name": "arm64-release-linux",

--- a/build/build.sh
+++ b/build/build.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+#
+# Build functions for the repository - predominantly used by build pipelines,
+# to keep specific build logic output of pipeline yml files allowing control
+# of build functions, outside of the generic build templates.
+#
+# usage: ./build/build.sh <build-function> {params}
+#
+#####
+
+# set -x
+set -eu # fail on error, and undefined var usage
+
+cmake_preset() {
+  PRESET=${1:-}
+  if [[ -z "$PRESET" ]]; then
+   echo "PRESET is required input"
+   cmake --list-presets
+   return
+  fi
+  echo "Building preset: $PRESET"
+  ldd --version
+  cmake --preset $PRESET # configure/generate (./out/build)
+}
+
+cmake_build() {
+  PRESET=${1:-}
+  if [[ -z "$PRESET" ]]; then
+   echo "PRESET is required input"
+   cmake --list-presets
+   return
+  fi
+  cmake_preset $PRESET
+  cmake --build --preset $PRESET # build
+}
+
+cmake_build_target() {
+  PRESET=${1:-}
+  TARGET=${2:-}
+  if [[ -z "$PRESET" ]]; then
+   echo "PRESET is required input"
+   cmake --list-presets
+   return
+  fi
+  cmake --build --preset $PRESET --target $TARGET
+}
+
+cmake_test() {
+  PRESET=${1:-}
+  cmake_build $PRESET
+  cmake_build_target $PRESET test
+}
+
+cmake_install() {
+  PRESET=${1:-}
+  cmake_build $PRESET
+  cmake_build_target $PRESET install
+}
+
+cmake_package() {
+  PRESET=${1:-}
+  cmake_build $PRESET
+  cmake_build_target $PRESET package
+}
+
+docker_run_linux_228_build_container() {
+  src_local="."
+  src="/home/src/amalgam"
+  ct_name="ghcr.io/howsoai/amalgam-build-container-linux-228"
+  ct_tag="latest"
+  echo "docker run -it -w $src -v $src_local:$src $ct_name:$ct_tag"
+  docker run -it -w $src -v "$src_local:$src" "$ct_name:$ct_tag"
+}
+
+# Show usage, and print functions
+help() {
+  echo "usage: ./bin/build.sh <build-function> {params}"
+  echo " where <build-function> one of :-"
+  IFS=$'\n'
+  for f in $(declare -F); do
+    echo "    ${f:11}"
+  done
+}
+
+# Takes the cli params, and runs them, defaulting to 'help()'
+if [ ! ${1:-} ]; then
+  help
+else
+  "$@"
+fi

--- a/build/cmake/global_settings.cmake
+++ b/build/cmake/global_settings.cmake
@@ -101,6 +101,16 @@ if(IS_UNIX)
     endif()
 endif()
 
+# GLIBC_VERSION
+if(IS_UNIX)
+    set(GLIBC_VERSION "unknown")
+    execute_process(COMMAND bash "-c" "ldd --version | head -n1 | grep -oEe '([[:digit:]]).([[:digit:]]*)'"
+                    RESULT_VARIABLE LDD_RETURN_CODE
+                    OUTPUT_VARIABLE GLIBC_VERSION
+                    OUTPUT_STRIP_TRAILING_WHITESPACE
+                    )
+endif()
+
 # Exe ext for WASM:
 if(IS_WASM)
     set(CMAKE_EXECUTABLE_SUFFIX ".cjs")


### PR DESCRIPTION
- presets for build: amd64-debug-linux-228, amd64-release-linux-228
- presets for test: amd64-debug-linux-228, amd64-release-linux-228
- add glibc version output
- add build/build.sh convenience script for running build locally within a build container.
- add smoke test and add to changelog