### PR TITLE
22209: Updates package name of GLIBC 2.28 build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -146,6 +146,12 @@ jobs:
       - name: CMake Package
         run: cmake --build --preset $PRESET --target package
 
+      - name: Rename Package
+        run: |
+          # Necessary so that there are no naming conflicts between the two amd64 packages (GLIBC 2.28/2.29) at release time,
+          # where GitHub does not allow a distinct "artifact name"
+          mv ./out/package/amalgam-*.tar.gz ./out/package/amalgam-${{ inputs.version }}-${{ matrix.preset.platform }}-${{ matrix.preset.arch }}-228.tar.gz
+
       - name: Upload Artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -343,7 +343,7 @@ jobs:
       - name: Extract Amalgam
         run: |
           mkdir ./amalgam
-          tar -xvf ./amalgam-${{ inputs.version }}-linux-amd64.tar.gz -C ./amalgam
+          tar -xvf ./amalgam-${{ inputs.version }}-linux-amd64-228.tar.gz -C ./amalgam
 
       - name: Smoke test
         run: |


### PR DESCRIPTION
Necessary to avoid a naming conflict during releases between the two Linux/amd64 builds.