### PR TITLE
22325: Fixes MacOS homebrew Python install

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -192,7 +192,6 @@ jobs:
           echo "Brew version: $(brew --version)"
           echo "Brew python installs: $(brew list | grep python)"
           if [ "${{ matrix.preset.arch }}" = "arm64" ]; then
-            brew unlink python@3.11
             brew unlink python@3.12
             brew link --force --overwrite python@3.12
 


### PR DESCRIPTION
There was a recent upgrade to the default Python version in GitHub's MacOS runners that caused an unexpected build failure.