### PR TITLE
22484: Fix assign_entity_roots transaction logs.

### DIFF
--- a/src/Amalgam/entity/EntityExternalInterface.cpp
+++ b/src/Amalgam/entity/EntityExternalInterface.cpp
@@ -289,7 +289,7 @@ std::pair<std::string, std::string> EntityExternalInterface::ExecuteEntityJSONLo
 	enm.FreeNodeTreeIfPossible(returned_value);
 	std::string json_out = converted ? result : string_intern_pool.GetStringFromID(string_intern_pool.NOT_A_STRING_ID);
 
-	std::string log = Parser::Unparse(logger.GetWrites(), false, false);
+	std::string log = Parser::Unparse(logger.GetWrites(), false);
 
 	return std::pair(json_out, log);
 }

--- a/src/Amalgam/entity/EntityWriteListener.cpp
+++ b/src/Amalgam/entity/EntityWriteListener.cpp
@@ -141,8 +141,9 @@ void EntityWriteListener::LogWriteToEntityRoot(Entity *entity)
 
 	EvaluableNode *new_write = BuildNewWriteOperation(ENT_ASSIGN_ENTITY_ROOTS, entity);
 	EvaluableNode *new_root = entity->GetRoot(&listenerStorage, EvaluableNodeManager::ENMM_LABEL_ESCAPE_INCREMENT);
-
-	new_write->AppendOrderedChildNode(new_root);
+	EvaluableNode *new_lambda = listenerStorage.AllocNode(EvaluableNodeType::ENT_LAMBDA);
+	new_lambda->AppendOrderedChildNode(new_root);
+	new_write->AppendOrderedChildNode(new_lambda);
 
 	LogNewEntry(new_write);
 }

--- a/test/lib_smoke_test/counter2.amlg
+++ b/test/lib_smoke_test/counter2.amlg
@@ -1,0 +1,35 @@
+; An entity that contains some number of named counters in a sub-entity.
+(null
+    #!id
+    ""
+
+    #initialize
+    (assign_to_entities
+        (assoc
+            !id (first (create_entities (lambda (list))))
+        )
+    )
+
+    #get_value
+    (declare
+        (assoc
+            counter "x"
+            id (retrieve_from_entity "!id")
+        )
+        (retrieve_from_entity id counter)
+    )
+
+    #add
+    (declare
+        (assoc
+            counter "x"
+            count 1
+            id (retrieve_from_entity "!id")
+        )
+        (if (contains_label id counter)
+            (accum_to_entities id (associate counter count))
+            (accum_entity_roots id (list (set_labels count (list counter))))
+        )
+        (retrieve_from_entity id counter)
+    )
+)


### PR DESCRIPTION
If any form of transaction logging is turned on, wrap the node of the assign_entity_roots call in a lambda so that labels don't get lost.

In the EvalEntityJsonPtrLogged() API call, make sure to emit labels in the log entry that comes back.