### PR TITLE
22497: Fixes segfaults for index_min and index_max with null keys

### DIFF
--- a/src/Amalgam/Parser.cpp
+++ b/src/Amalgam/Parser.cpp
@@ -149,16 +149,6 @@ std::string Parser::Unparse(EvaluableNode *tree,
 	return upd.result;
 }
 
-EvaluableNodeReference Parser::ParseFromKeyString(const std::string &code_string, EvaluableNodeManager *enm)
-{
-	if(code_string.size() == 0 || code_string[0] != '\0')
-		return EvaluableNodeReference(enm->AllocNode(ENT_STRING, code_string), true);
-
-	std::string_view escaped_string(&code_string[1], code_string.size() - 1);
-	auto [node, warnings, char_with_error] = Parser::Parse(escaped_string, enm);
-	return node;
-}
-
 EvaluableNodeReference Parser::ParseFromKeyStringId(StringInternPool::StringID code_string_id,
 	EvaluableNodeManager *enm)
 {

--- a/src/Amalgam/Parser.h
+++ b/src/Amalgam/Parser.h
@@ -136,9 +136,6 @@ public:
 		bool expanded_whitespace = true, bool emit_attributes = true, bool sort_keys = false,
 		bool first_of_transactional_unparse = false, size_t starting_indendation = 0);
 
-	//transforms the code_string into evaluable nodes
-	static EvaluableNodeReference ParseFromKeyString(const std::string &code_string, EvaluableNodeManager *enm);
-
 	//transforms the code_string_id into evaluable nodes
 	static EvaluableNodeReference ParseFromKeyStringId(StringInternPool::StringID code_string_id, EvaluableNodeManager *enm);
 

--- a/src/Amalgam/interpreter/Interpreter.h
+++ b/src/Amalgam/interpreter/Interpreter.h
@@ -1314,7 +1314,7 @@ protected:
 
 			for(StringInternPool::StringID max_key : max_keys)
 			{
-				EvaluableNodeReference parsedKey = Parser::ParseFromKeyString(max_key->string, evaluableNodeManager);
+				EvaluableNodeReference parsedKey = Parser::ParseFromKeyStringId(max_key, evaluableNodeManager);
 				index_list.UpdatePropertiesBasedOnAttachedNode(parsedKey);
 				index_list_ocn.push_back(parsedKey);
 			}


### PR DESCRIPTION
Also cleans out unneeded method