### PR TITLE
23044: Upgrades Ubuntu runner from 20.04 to 24.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ defaults:
 
 jobs:
   build-linux:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     container:
       image: ghcr.io/howsoai/amalgam-build-container-linux:2.0.8
       credentials:


### PR DESCRIPTION
The Ubuntu 20.04 runner has been deprecated and will soon be removed.