### PR TITLE
24630: load/store to/from memory, entities, MAJOR

### DIFF
--- a/TRACE-FILES.md
+++ b/TRACE-FILES.md
@@ -1,0 +1,138 @@
+# Trace Files
+
+The Amalgam runtime uses a simple line-oriented format to record and replay API operations.  If you run the Amalgam CLI tool like `amalgam-st --trace`, you can type these commands directly into the tool to run top-level Amalgam API operations without necessarily writing a C program.
+
+The [Amalgam Python client library](https://github.com/howsoai/amalgam-lang-py) can generate trace files if an option `trace=True` is passed to the `Amalgam()` constructor.  The Amalgam CLI tool can consume these trace files via the `amalgam-st --tracefile [file]` option.  Trace files can be hand-written if needed.
+
+## Syntax
+
+Blank lines and lines that begin with a comment marker, `#` followed by at least one space, are ignored.  Lines with unknown commands or syntactic errors are ignored, and do not stop execution.
+
+Command lines contain a command name followed by some number of space-separated arguments.  An argument may appear in double quotes; if it does, the argument continues through the next matching double-quote.  If a double-quote is needed in an argument value, it may be preceded by a backslash.  No other escaping is possible or allowed, and backslashes that are not followed by double quotes are literally read as backslashes.  If ASCII double-quote bytes 0x22 are escaped by preceding them with a backslash byte 0x5C then an item can otherwise contain arbitrary binary data.
+
+Some commands end with a JSON object.  This is passed directly as a string, and is not quoted or escaped in any way.  Other commands can take a JSON object as a parameter, and this must be quoted and escaped as described above.  Compare:
+
+```none
+LOAD_ENTITY "handle" "path" "" false "{\"executeOnLoad\": true}"
+SET_ENTITY_PERMISSIONS "handle" {"load": true, "store": true}
+```
+
+Several of the entity-related operations take a `persistent` parameter.  This is a Boolean value, true if the string is exactly `true` and false otherwise.  This is conventionally not quoted but double quotes will be recognized and removed.
+
+## Commands
+
+The commands mirror the C API in `Amalgam.h`.  Commands are as follows:
+
+```none
+LOAD_ENTITY "handle" "path" "file_type" persistent "json_payload" "transaction_listener_path" "print_listener_path" "rand_seed" "entity_path"
+```
+
+Load an entity from a file on disk.  `handle` and `path` are required, all other parameters are optional.  If `entity_path` is provided then it contains a space-separated ordered list of entity IDs, and the entity is loaded into an interior entity underneath an existing `handle`.
+
+```none
+LOAD_ENTITY_FROM_MEMORY "handle" "base64_data" "file_type" "persistent" "json_payload" "transaction_listener_path" "print_listener_path" "rand_seed" "entity_path"
+```
+
+Load an entity from a base64-encoded data string.  `handle`, `base64_data`, and `file_type` are all required.  Other parameters are handled as `LOAD_ENTITY`.
+
+```none
+GET_ENTITY_PERMISSIONS "handle"
+```
+
+Get the current permissions of the specified entity.  `handle` is required.
+
+```none
+SET_ENTITY_PERMISSIONS "handle" json
+```
+
+Set the permissions of an entity.  `handle` is required, and is followed by an unquoted JSON string with the actual permissions.
+
+```none
+CLONE_ENTITY "from_handle" "to_handle" "file_type" persistent "json_payload" "transaction_listener_path" "print_listener_path"
+```
+
+Make a copy of an existing entity.  The two handles are required.
+
+```none
+STORE_ENTITY "handle" "path" "file_type" persistent "json_payload" "entity_path"
+```
+
+Store an entity to a file on disk.  `handle` and `path` are required, other options default to the options provided when the entity was created.
+
+```none
+STORE_ENTITY_TO_MEMORY "handle" "file_type" persistent "json_payload" "entity_path"
+```
+
+Store an entity to memory.  `handle` is required, and the output of the trace operation is the base64-encoded entity data.
+
+```none
+DESTROY_ENTITY "handle"
+```
+
+Destroy an entity.  `handle` is required.
+
+```none
+SET_JSON_TO_LABEL "handle" "label" json
+```
+
+Set the value at some label within an existing entity.  `handle` and `label` are required, and are followed by an unquoted JSON string with the content to set.
+
+```none
+GET_JSON_FROM_LABEL "handle" "label"
+```
+
+Get the value at some label within an existing entity.  `handle` and `label` are required, and the output of the trace operation is the JSON-encoded value.
+
+```none
+EXECUTE_ENTITY_JSON "handle" "label" json
+```
+
+Execute some label within an existing entity, passing a JSON object as context.  `handle` and `label` are required, and are followed by an unquoted JSON string with values to set in the execution context.  If the JSON string is empty or absent, it is treated as an empty object `{}`.  The executing Amalgam code will see the keys and values of the JSON object as ordinary variables.  The output of the trace operation is the JSON-encoded result of executing the label.
+
+```none
+EXECUTE_ENTITY_JSON_LOGGED "handle" "label" json
+```
+
+As `EXECUTE_ENTITY_JSON`, but also writes out an Amalgam-syntax description of how the execution modified the entity.
+
+```none
+EVAL_ON_ENTITY "handle" "amlg"
+```
+
+Execute arbitrary Amalgam code in the context of an existing entity.  `handle` and `amlg` are required, and `amlg` must be correctly quoted.  The output of the trace operation is the JSON-encoded result of evaluating the expression.
+
+```none
+SET_RANDOM_SEED "handle" content
+```
+
+Sets the random seed of an existing entity to arbitrary binary data.  `handle` is required, and `content` are any bytes remaining after any whitespace through the end of the line.
+
+```none
+VERSION
+```
+
+The output of the trace operation is the current Amalgam library version.  Takes no parameters.
+
+```none
+VERIFY_ENTITY "path"
+```
+
+Check that a filesystem path can be loaded as an entity.  `path` is required.
+
+```none
+GET_MAX_NUM_THREADS
+```
+
+The output of the trace operation is the number of concurrent threads the Amalgam interpreter can use.  Error on non-multithreaded Amalgam runtimes such as `amalgam-st`.
+
+```none
+SET_MAX_NUM_THREADS n
+```
+
+Set the maximum number of threads in a multithreaded Amalgam runtime.  The parameter is an unquoted number with the number of threads, and must be greater than zero.  Error on non-multithreaded Amalgam runtimes such as `amalgam-st`.
+
+```none
+EXIT
+```
+
+End the trace file.

--- a/src/Amalgam/Amalgam.h
+++ b/src/Amalgam/Amalgam.h
@@ -22,6 +22,11 @@ extern "C"
 		bool loaded;
 		char *message;
 		char *version;
+		//If an entity_path parameter was passed to LoadEntity, the path where the entity was
+		//actually loaded.  If non-null, contains entity_path_len entries.  Both the entries
+		//and the array itself need to be freed via DeleteString.
+		char **entity_path;
+		size_t entity_path_len;
 	};
 
 	//output from ExecuteEntityJsonPtrLogged
@@ -33,7 +38,13 @@ extern "C"
 
 	//loads the entity specified into handle
 	AMALGAM_EXPORT LoadEntityStatus LoadEntity(char *handle, char *path, char *file_type,
-		bool persistent, char *json_file_params, char *write_log_filename, char *print_log_filename);
+		bool persistent, char *json_file_params, char *write_log_filename, char *print_log_filename,
+		const char **entity_path, size_t entity_path_len);
+
+	//loads the entity specified into handle, from a memory buffer
+	AMALGAM_EXPORT LoadEntityStatus LoadEntityFromMemory(char *handle, void *data, size_t len, char *file_type,
+		bool persistent, char *json_file_params, char *write_log_filename, char *print_log_filename,
+		const char **entity_path, size_t entity_path_len);
 
 	//verifies the entity specified by path. Uses LoadEntityStatus to return any errors and version
 	AMALGAM_EXPORT LoadEntityStatus VerifyEntity(char *path);
@@ -53,7 +64,12 @@ extern "C"
 		char *write_log_filename, char *print_log_filename);
 
 	//stores the entity specified by handle into path
-	AMALGAM_EXPORT void StoreEntity(char *handle, char *path, char *file_type, bool persistent, char *json_file_params);
+	AMALGAM_EXPORT void StoreEntity(char *handle, char *path, char *file_type, bool persistent, char *json_file_params,
+		const char **entity_path, size_t entity_path_len);
+
+	//stores the entity specified into a memory buffer
+	AMALGAM_EXPORT void StoreEntityToMemory(char *handle, void **data_p, size_t *len_p, char *file_type,
+		bool persistent, char *json_file_params, const char **entity_path, size_t entity_path_len);
 
 	//executes label on handle
 	AMALGAM_EXPORT void ExecuteEntity(char *handle, char *label);

--- a/src/Amalgam/AmalgamMain.cpp
+++ b/src/Amalgam/AmalgamMain.cpp
@@ -332,7 +332,8 @@ PLATFORM_MAIN_CONSOLE
 
 		if(write_log_filename != "")
 		{
-			EntityWriteListener *write_log = new EntityWriteListener(entity, false, false, false, write_log_filename);
+			std::unique_ptr<std::ostream> log_file = std::make_unique<std::ofstream>(write_log_filename, std::ios::binary);
+			EntityWriteListener *write_log = new EntityWriteListener(entity, std::move(log_file), false, false, false);
 			write_listeners.push_back(write_log);
 		}
 

--- a/src/Amalgam/AssetManager.cpp
+++ b/src/Amalgam/AssetManager.cpp
@@ -16,6 +16,7 @@
 #include <fstream>
 #include <iostream>
 #include <regex>
+#include <sstream>
 
 AssetManager asset_manager;
 
@@ -42,6 +43,7 @@ AssetManager::AssetParameters::AssetParameters(std::string resource_path, std::s
 		parallelCreate = false;
 		executeOnLoad = false;
 		requireVersionCompatibility = true;
+		toMemory = false;
 	}
 	else if(resourceType == FILE_EXTENSION_JSON || resourceType == FILE_EXTENSION_YAML
 		|| resourceType == FILE_EXTENSION_CSV)
@@ -56,6 +58,7 @@ AssetManager::AssetParameters::AssetParameters(std::string resource_path, std::s
 		parallelCreate = false;
 		executeOnLoad = false;
 		requireVersionCompatibility = false;
+		toMemory = false;
 	}
 	else if(resourceType == FILE_EXTENSION_COMPRESSED_AMALGAM_CODE)
 	{
@@ -69,6 +72,7 @@ AssetManager::AssetParameters::AssetParameters(std::string resource_path, std::s
 		parallelCreate = false;
 		executeOnLoad = is_entity;
 		requireVersionCompatibility = true;
+		toMemory = false;
 	}
 	else
 	{
@@ -82,6 +86,7 @@ AssetManager::AssetParameters::AssetParameters(std::string resource_path, std::s
 		parallelCreate = false;
 		executeOnLoad = is_entity;
 		requireVersionCompatibility = false;
+		toMemory = false;
 	}
 
 	UpdateResources();
@@ -225,13 +230,20 @@ EvaluableNodeReference AssetManager::LoadResource(AssetParameters *asset_params,
 	//load this entity based on file_type
 	if(asset_params->resourceType == FILE_EXTENSION_AMALGAM || asset_params->resourceType == FILE_EXTENSION_AMLG_METADATA)
 	{
-		auto [code, code_success] = Platform_OpenFileAsString(asset_params->resourcePath);
-		if(!code_success)
+		std::string code;
+		if(asset_params->toMemory)
+			code = asset_params->resourceContents;
+		else
 		{
-			status.SetStatus(false, code);
-			if(asset_params->resourceType == FILE_EXTENSION_AMALGAM)
-				std::cerr << code << std::endl;
-			return EvaluableNodeReference::Null();
+			bool code_success;
+			std::tie(code, code_success) = Platform_OpenFileAsString(asset_params->resourcePath);
+			if(!code_success)
+			{
+				status.SetStatus(false, code);
+				if(asset_params->resourceType == FILE_EXTENSION_AMALGAM)
+					std::cerr << code << std::endl;
+				return EvaluableNodeReference::Null();
+			}
 		}
 
 		StringManipulation::RemoveBOMFromUTF8String(code);
@@ -243,20 +255,48 @@ EvaluableNodeReference AssetManager::LoadResource(AssetParameters *asset_params,
 	}
 	else if(asset_params->resourceType == FILE_EXTENSION_JSON)
 	{
+		if(asset_params->toMemory)
+		{
+			status.SetStatus(false, "Cannot load " + asset_params->resourceType + " from memory");
+			return EvaluableNodeReference::Null();
+		}
 		return EvaluableNodeReference(EvaluableNodeJSONTranslation::Load(asset_params->resourcePath, enm, status), true);
 	}
 	else if(asset_params->resourceType == FILE_EXTENSION_YAML)
 	{
+		if(asset_params->toMemory)
+		{
+			status.SetStatus(false, "Cannot load " + asset_params->resourceType + " from memory");
+			return EvaluableNodeReference::Null();
+		}
 		return EvaluableNodeReference(EvaluableNodeYAMLTranslation::Load(asset_params->resourcePath, enm, status), true);
 	}
 	else if(asset_params->resourceType == FILE_EXTENSION_CSV)
 	{
+		if(asset_params->toMemory)
+		{
+			status.SetStatus(false, "Cannot load " + asset_params->resourceType + " from memory");
+			return EvaluableNodeReference::Null();
+		}
 		return EvaluableNodeReference(FileSupportCSV::Load(asset_params->resourcePath, enm, status), true);
 	}
 	else if(asset_params->resourceType == FILE_EXTENSION_COMPRESSED_AMALGAM_CODE)
 	{
 		BinaryData compressed_data;
-		auto [error_msg, version, success] = LoadFileToBuffer<BinaryData>(asset_params->resourcePath, asset_params->resourceType, compressed_data);
+		// LoadStreamToBuffer reads the caml header and we must use it here.
+		std::string error_msg;
+		std::string version;
+		bool success;
+		if(asset_params->toMemory)
+		{
+			std::istringstream ins(asset_params->resourceContents);
+			std::tie(error_msg, version, success) = LoadStreamToBuffer(ins, asset_params->resourceType, compressed_data);
+		}
+		else
+		{
+			std::ifstream inf(asset_params->resourceContents, std::ios::binary);
+			std::tie(error_msg, version, success) = LoadStreamToBuffer<BinaryData>(inf, asset_params->resourceType, compressed_data);
+		}
 		if(!success)
 		{
 			status.SetStatus(false, error_msg, version);
@@ -273,15 +313,17 @@ EvaluableNodeReference AssetManager::LoadResource(AssetParameters *asset_params,
 	}
 	else //just load the file as a string
 	{
+		if(asset_params->toMemory)
+			return EvaluableNodeReference(enm->AllocNode(ENT_STRING, asset_params->resourceContents), true);
 		std::string s;
-		auto [error_msg, version, success] = LoadFileToBuffer<std::string>(asset_params->resourcePath, asset_params->resourceType, s);
-		if(success)
-			return EvaluableNodeReference(enm->AllocNode(ENT_STRING, s), true);
-		else
+		std::ifstream f(asset_params->resourcePath, std::fstream::binary | std::fstream::in);
+		auto [error_msg, version, success] = LoadStreamToBuffer<std::string>(f, asset_params->resourceType, s);
+		if(!success)
 		{
 			status.SetStatus(false, error_msg, version);
 			return EvaluableNodeReference::Null();
 		}
+		return EvaluableNodeReference(enm->AllocNode(ENT_STRING, s), true);
 	}
 }
 
@@ -291,19 +333,36 @@ EntityExternalInterface::LoadEntityStatus AssetManager::LoadResourceViaTransacti
 	std::string code_string;
 	if(asset_params->resourceType == FILE_EXTENSION_AMALGAM)
 	{
-		bool code_success = false;
-		std::tie(code_string, code_success) = Platform_OpenFileAsString(asset_params->resourcePath);
-		if(!code_success)
+		if(asset_params->toMemory)
+			code_string = asset_params->resourceContents;
+		else
 		{
-			if(asset_params->resourceType == FILE_EXTENSION_AMALGAM)
-				std::cerr << code_string << std::endl;
-			return EntityExternalInterface::LoadEntityStatus(false, code_string);
+			bool code_success = false;
+			std::tie(code_string, code_success) = Platform_OpenFileAsString(asset_params->resourcePath);
+			if(!code_success)
+			{
+				if(asset_params->resourceType == FILE_EXTENSION_AMALGAM)
+					std::cerr << code_string << std::endl;
+				return EntityExternalInterface::LoadEntityStatus(false, code_string);
+			}
 		}
 	}
 	else if(asset_params->resourceType == FILE_EXTENSION_COMPRESSED_AMALGAM_CODE)
 	{
 		BinaryData compressed_data;
-		auto [error_msg, version, success] = LoadFileToBuffer<BinaryData>(asset_params->resourcePath, asset_params->resourceType, compressed_data);
+		std::string error_msg;
+		std::string version;
+		bool success;
+		if(asset_params->toMemory)
+		{
+			std::istringstream ins(asset_params->resourceContents);
+			std::tie(error_msg, version, success) = LoadStreamToBuffer(ins, asset_params->resourceType, compressed_data);
+		}
+		else
+		{
+			std::ifstream inf(asset_params->resourcePath, std::ios::binary);
+			std::tie(error_msg, version, success) = LoadStreamToBuffer(inf, asset_params->resourceType, compressed_data);
+		}
 		if(!success)
 			return EntityExternalInterface::LoadEntityStatus(false, error_msg, version);
 
@@ -370,7 +429,7 @@ EntityExternalInterface::LoadEntityStatus AssetManager::LoadResourceViaTransacti
 		auto [error_message, success] = AssetManager::ValidateVersionAgainstAmalgam(version_string);
 		load_status.SetStatus(success || !asset_params->requireVersionCompatibility, error_message, version_string);
 	}
-	
+
 	entity->evaluableNodeManager.FreeNode(args);
 	entity->evaluableNodeManager.FreeNode(scope_stack);
 
@@ -382,26 +441,34 @@ bool AssetManager::StoreResource(EvaluableNode *code, AssetParameters *asset_par
 	//store the entity based on file_type
 	if(asset_params->resourceType == FILE_EXTENSION_AMALGAM || asset_params->resourceType == FILE_EXTENSION_AMLG_METADATA)
 	{
-		std::ofstream outf(asset_params->resourcePath, std::ios::out | std::ios::binary);
-		if(!outf.good())
-			return false;
-
 		std::string code_string = Parser::Unparse(code, asset_params->prettyPrint, true, asset_params->sortKeys);
-		outf.write(code_string.c_str(), code_string.size());
-		outf.close();
-
+		if(asset_params->toMemory)
+			asset_params->resourceContents = std::move(code_string);
+		else
+		{
+			std::ofstream outf(asset_params->resourcePath, std::ios::out | std::ios::binary);
+			if(!outf.good())
+				return false;
+			outf.write(code_string.c_str(), code_string.size());
+		}
 		return true;
 	}
 	else if(asset_params->resourceType == FILE_EXTENSION_JSON)
 	{
+		if(asset_params->toMemory)
+			return false;
 		return EvaluableNodeJSONTranslation::Store(code, asset_params->resourcePath, enm, asset_params->sortKeys);
 	}
 	else if(asset_params->resourceType == FILE_EXTENSION_YAML)
 	{
+		if(asset_params->toMemory)
+			return false;
 		return EvaluableNodeYAMLTranslation::Store(code, asset_params->resourcePath, enm, asset_params->sortKeys);
 	}
 	else if(asset_params->resourceType == FILE_EXTENSION_CSV)
 	{
+		if(asset_params->toMemory)
+			return false;
 		return FileSupportCSV::Store(code, asset_params->resourcePath, enm);
 	}
 	else if(asset_params->resourceType == FILE_EXTENSION_COMPRESSED_AMALGAM_CODE)
@@ -409,7 +476,19 @@ bool AssetManager::StoreResource(EvaluableNode *code, AssetParameters *asset_par
 		std::string code_string = Parser::Unparse(code, asset_params->prettyPrint, true, asset_params->sortKeys);
 		auto [compressed_data, huffman_tree] = CompressString(code_string);
 		delete huffman_tree;
-		return StoreFileFromBuffer<BinaryData>(asset_params->resourcePath, asset_params->resourceType, compressed_data);
+		// StoreFileFromBuffer() writes the caml header and we must use it here.
+		if(asset_params->toMemory)
+		{
+			std::ostringstream outs;
+			bool result = StoreFileFromBuffer(outs, asset_params->resourceType, compressed_data);
+			asset_params->resourceContents = outs.str();
+			return result;
+		}
+		else
+		{
+			std::ofstream outf(asset_params->resourcePath, std::ios::out | std::ios::binary);
+			return StoreFileFromBuffer<BinaryData>(outf, asset_params->resourceType, compressed_data);
+		}
 	}
 	else //binary string
 	{
@@ -417,7 +496,13 @@ bool AssetManager::StoreResource(EvaluableNode *code, AssetParameters *asset_par
 			return false;
 
 		const std::string &s = code->GetStringValue();
-		return StoreFileFromBuffer<std::string>(asset_params->resourcePath, asset_params->resourceType, s);
+		if(asset_params->toMemory)
+			asset_params->resourceContents = s;
+		else
+		{
+			std::ofstream outf(asset_params->resourcePath, std::ios::out | std::ios::binary);
+			return StoreFileFromBuffer<std::string>(outf, asset_params->resourceType, s);
+		}
 	}
 
 	return false;
@@ -501,6 +586,10 @@ Entity *AssetManager::LoadEntityFromResource(AssetParametersRef &asset_params, b
 
 	new_entity->SetRoot(code, true);
 
+	//all of steps beyond this depend on loading an entity from disk
+	if(asset_params->toMemory)
+		return new_entity;
+
 	if(asset_params->resourceType == FILE_EXTENSION_AMALGAM)
 	{
 		//load any metadata like random seed
@@ -565,7 +654,7 @@ Entity *AssetManager::LoadEntityFromResource(AssetParametersRef &asset_params, b
 		std::string ce_resource_base_path = contained_entities_directory + ce_file_base;
 		AssetParametersRef ce_asset_params
 			= asset_params->CreateAssetParametersForContainedResourceByResourceBasePath(ce_resource_base_path);
-		
+
 		Entity *contained_entity = LoadEntityFromResource(ce_asset_params, persistent,
 			default_seed, calling_interpreter, status);
 

--- a/src/Amalgam/entity/EntityWriteListener.h
+++ b/src/Amalgam/entity/EntityWriteListener.h
@@ -18,14 +18,14 @@ public:
 	//if retain_writes is true, then the listener will store the writes, and GetWrites() will return the list of all writes accumulated
 	//if _pretty is true, then the listener will pretty print to filename
 	//if sort_keys is true, then the listener will print with keys sorted for assocs
-	//if filename is not empty, then it will attempt to open the file and log all writes to that file, and then flush the file stream
-	EntityWriteListener(Entity *listening_entity, bool retain_writes = false,
-		bool _pretty = false, bool sort_keys = false, const std::string &filename = std::string());
+	//if transaction_file is not empty, then it takes ownership of the file, logging all writes and flushing the stream after each
+	EntityWriteListener(Entity *listening_entity, std::unique_ptr<std::ostream> &&transaction_file, bool retain_writes = false,
+		bool _pretty = false, bool sort_keys = false);
 
 	//stores all writes, appending them to transaction_file
 	//if huffman_tree is not null, the write listener will assume ownership of the memory and use it to compress output
 	EntityWriteListener(Entity *listening_entity,
-		bool _pretty, bool sort_keys, std::ofstream &transaction_file, HuffmanTree<uint8_t> *huffman_tree = nullptr);
+		bool _pretty, bool sort_keys, std::unique_ptr<std::ostream> &&transaction_file, HuffmanTree<uint8_t> *huffman_tree = nullptr);
 
 	~EntityWriteListener();
 
@@ -78,7 +78,7 @@ protected:
 	EvaluableNodeManager listenerStorage;
 
 	EvaluableNode *storedWrites;
-	std::ofstream logFile;
+	std::unique_ptr<std::ostream> logFile;
 	//used for compressing output if not nullptr; this memory is managed by this listener and must be freed
 	HuffmanTree<uint8_t> *huffmanTree;
 

--- a/src/Amalgam/importexport/FileSupportCAML.cpp
+++ b/src/Amalgam/importexport/FileSupportCAML.cpp
@@ -7,7 +7,7 @@
 //system headers:
 #include <cstdint>
 #include <cstring>
-#include <fstream>
+#include <istream>
 #include <ostream>
 #include <string>
 #include <tuple>
@@ -15,7 +15,7 @@
 //magic number written at beginning of CAML file
 static const uint8_t s_magic_number[] = { 'c', 'a', 'm', 'l' };
 
-bool ReadBigEndian(std::ifstream &stream, uint32_t &val)
+bool ReadBigEndian(std::istream &stream, uint32_t &val)
 {
 	uint8_t buffer[4] = { 0 };
 	if(!stream.read(reinterpret_cast<char *>(buffer), sizeof(uint32_t)))
@@ -30,7 +30,7 @@ bool ReadBigEndian(std::ifstream &stream, uint32_t &val)
 	return true;
 }
 
-bool WriteBigEndian(std::ofstream &stream, const uint32_t &val)
+bool WriteBigEndian(std::ostream &stream, const uint32_t &val)
 {
 	uint8_t buffer[4] = { 0 };
 	buffer[0] = (val >> 24) & 0xFF;
@@ -42,7 +42,7 @@ bool WriteBigEndian(std::ofstream &stream, const uint32_t &val)
 	return true;
 }
 
-bool ReadVersion(std::ifstream &stream, uint32_t &major, uint32_t &minor, uint32_t &patch)
+bool ReadVersion(std::istream &stream, uint32_t &major, uint32_t &minor, uint32_t &patch)
 {
 	if(!ReadBigEndian(stream, major))
 		return false;
@@ -54,7 +54,7 @@ bool ReadVersion(std::ifstream &stream, uint32_t &major, uint32_t &minor, uint32
 	return true;
 }
 
-bool WriteVersion(std::ofstream &stream)
+bool WriteVersion(std::ostream &stream)
 {
 	if(!WriteBigEndian(stream, AMALGAM_VERSION_MAJOR))
 		return false;
@@ -66,7 +66,7 @@ bool WriteVersion(std::ofstream &stream)
 	return true;
 }
 
-std::tuple<std::string, std::string, bool> FileSupportCAML::ReadHeader(std::ifstream &stream, size_t &header_size)
+std::tuple<std::string, std::string, bool> FileSupportCAML::ReadHeader(std::istream &stream, size_t &header_size)
 {
 	uint8_t magic[4] = { 0 };
 	if(!stream.read(reinterpret_cast<char *>(magic), sizeof(magic)))
@@ -96,11 +96,11 @@ std::tuple<std::string, std::string, bool> FileSupportCAML::ReadHeader(std::ifst
 		if(!success)
 			return std::make_tuple(error_message, version, false);
 	}
-	
+
 	return std::make_tuple("", version, true);
 }
 
-bool FileSupportCAML::WriteHeader(std::ofstream &stream)
+bool FileSupportCAML::WriteHeader(std::ostream &stream)
 {
 	if(!stream.write(reinterpret_cast<const char *>(s_magic_number), sizeof(s_magic_number)))
 		return false;

--- a/src/Amalgam/importexport/FileSupportCAML.h
+++ b/src/Amalgam/importexport/FileSupportCAML.h
@@ -1,7 +1,7 @@
 #pragma once
 
 //system headers:
-#include <fstream>
+#include <istream>
 #include <ostream>
 #include <string>
 #include <tuple>
@@ -12,8 +12,8 @@ namespace FileSupportCAML
 	//read the header from the stream
 	//if success: returns an empty string indicating no error, file version, and true
 	//if failure: returns error message, file version, and false
-	std::tuple<std::string, std::string, bool> ReadHeader(std::ifstream &stream, size_t &header_size);
+	std::tuple<std::string, std::string, bool> ReadHeader(std::istream &stream, size_t &header_size);
 
 	//write the header to the stream
-	bool WriteHeader(std::ofstream &stream);
+	bool WriteHeader(std::ostream &stream);
 };

--- a/src/Amalgam/interpreter/InterpreterOpcodesEntityAccess.cpp
+++ b/src/Amalgam/interpreter/InterpreterOpcodesEntityAccess.cpp
@@ -305,7 +305,7 @@ EvaluableNodeReference Interpreter::InterpretNode_ENT_ASSIGN_TO_ENTITIES_and_DIR
 			#endif
 
 			target_entity->CollectGarbageWithEntityWriteReference();
-			
+
 			#ifdef AMALGAM_MEMORY_INTEGRITY
 				VerifyEvaluableNodeIntegrity();
 			#endif
@@ -456,7 +456,7 @@ EvaluableNodeReference Interpreter::InterpretNode_ENT_CALL_ENTITY_and_CALL_ENTIT
 	EvaluableNodeReference args = EvaluableNodeReference::Null();
 	if(ocn.size() > 2)
 		args = InterpretNodeForImmediateUse(ocn[2]);
-	
+
 	auto node_stack = CreateOpcodeStackStateSaver(args);
 
 	//current pointer to write listeners
@@ -469,7 +469,7 @@ EvaluableNodeReference Interpreter::InterpretNode_ENT_CALL_ENTITY_and_CALL_ENTIT
 		// keep the copying here in this if statement so don't need to make copies when not calling ENT_CALL_ENTITY_GET_CHANGES
 		if(writeListeners != nullptr)
 			get_changes_write_listeners = *writeListeners;
-		get_changes_write_listeners.push_back(new EntityWriteListener(curEntity, true));
+		get_changes_write_listeners.push_back(new EntityWriteListener(curEntity, std::unique_ptr<std::ostream>(), true));
 		cur_write_listeners = &get_changes_write_listeners;
 	}
 

--- a/test/lib_smoke_test/main.cpp
+++ b/test/lib_smoke_test/main.cpp
@@ -16,7 +16,8 @@ class ApiString
 	char *p;
 
 public:
-	ApiString(char *p) : p(p) {}
+	ApiString(char *p) : p(p)
+	{}
 	ApiString(const ApiString &a) = delete;
 	ApiString(ApiString &&a) : p(a.p)
 	{
@@ -42,7 +43,8 @@ class LoadedEntity
 	std::string h;
 
 public:
-	LoadedEntity(const std::string &handle) : h(handle) {}
+	LoadedEntity(const std::string &handle) : h(handle)
+	{}
 
 	~LoadedEntity()
 	{
@@ -61,9 +63,11 @@ class TestResult
 	bool successful;
 
 public:
-	TestResult(const std::string &test) : test(test), successful(true) {}
+	TestResult(const std::string &test) : test(test), successful(true)
+	{}
 
-	operator bool() const {
+	operator bool() const
+	{
 		return successful;
 	}
 
@@ -92,14 +96,15 @@ class SuiteResult
 	bool successful;
 
 public:
-	SuiteResult(bool verbose) : verbose(verbose), successful(true) {}
+	SuiteResult(bool verbose) : verbose(verbose), successful(true)
+	{}
 
 	operator bool() const
 	{
 		return successful;
 	}
 
-	void Run(const std::string &test, std::function<void(TestResult&)> f)
+	void Run(const std::string &test, std::function<void(TestResult &)> f)
 	{
 		TestResult test_result(test);
 		if(verbose)
@@ -119,12 +124,12 @@ static void LoadAndEval(TestResult &test_result)
 {
 	// Load+execute+delete entity:
 	char handle[] = "1";
-	char* file = (char*)"test.amlg";
+	char *file = (char *)"test.amlg";
 	char file_type[] = "";
 	char json_file_params[] = "";
 	char write_log[] = "";
 	char print_log[] = "";
-	auto status = LoadEntity(handle, file, file_type, false, json_file_params, write_log, print_log);
+	auto status = LoadEntity(handle, file, file_type, false, json_file_params, write_log, print_log, nullptr, 0);
 	test_result.Require("LoadEntity", status.loaded);
 	if(test_result)
 	{
@@ -148,10 +153,15 @@ static std::string initialize("initialize");
 static std::string add("add");
 static std::string get_value("get_value");
 static std::string increment("increment");
+static std::string amlgSuffix("amlg");
+static std::string camlSuffix("caml");
+// This string shows up at the start of persisted entities
+static std::string declare("(declare\r\n\t{create_new_entity (true)");
+
 
 static void InitializeCounter(TestResult &test_result)
 {
-    LoadEntityStatus status = LoadEntity(handle.data(), filename.data(), empty.data(), false, empty.data(), empty.data(), empty.data());
+	LoadEntityStatus status = LoadEntity(handle.data(), filename.data(), empty.data(), false, empty.data(), empty.data(), empty.data(), nullptr, 0);
 	test_result.Require("LoadEntity", status.loaded);
 	if(test_result)
 	{
@@ -164,7 +174,7 @@ static void InitializeCounter(TestResult &test_result)
 
 static void ExecuteEntityJsonWithValue(TestResult &test_result)
 {
-    LoadEntityStatus status = LoadEntity(handle.data(), filename.data(), empty.data(), false, empty.data(), empty.data(), empty.data());
+	LoadEntityStatus status = LoadEntity(handle.data(), filename.data(), empty.data(), false, empty.data(), empty.data(), empty.data(), nullptr, 0);
 	test_result.Require("LoadEntity", status.loaded);
 	if(test_result)
 	{
@@ -178,13 +188,13 @@ static void ExecuteEntityJsonWithValue(TestResult &test_result)
 
 static void ExecuteEntityJsonLogged(TestResult &test_result)
 {
-    LoadEntityStatus status = LoadEntity(handle.data(), filename.data(), empty.data(), false, empty.data(), empty.data(), empty.data());
+	LoadEntityStatus status = LoadEntity(handle.data(), filename.data(), empty.data(), false, empty.data(), empty.data(), empty.data(), nullptr, 0);
 	test_result.Require("LoadEntity", status.loaded);
 	if(test_result)
 	{
 		LoadedEntity loaded_entity(handle);
 		ExecuteEntity(handle.data(), initialize.data());
-	    ResultWithLog result = ExecuteEntityJsonPtrLogged(handle.data(), increment.data(), empty.data());
+		ResultWithLog result = ExecuteEntityJsonPtrLogged(handle.data(), increment.data(), empty.data());
 		ApiString json(result.json);
 		ApiString log(result.log);
 		test_result.Check("ExecuteEntityJsonPtrLogged json", json, "1");
@@ -194,7 +204,7 @@ static void ExecuteEntityJsonLogged(TestResult &test_result)
 
 static void ExecuteEntityJsonLoggedUpdating(TestResult &test_result)
 {
-    LoadEntityStatus status = LoadEntity(handle.data(), filename.data(), empty.data(), false, empty.data(), empty.data(), empty.data());
+	LoadEntityStatus status = LoadEntity(handle.data(), filename.data(), empty.data(), false, empty.data(), empty.data(), empty.data(), nullptr, 0);
 	test_result.Require("LoadEntity", status.loaded);
 	if(test_result)
 	{
@@ -204,7 +214,7 @@ static void ExecuteEntityJsonLoggedUpdating(TestResult &test_result)
 		ApiString one(ExecuteEntityJsonPtr(handle.data(), increment.data(), empty.data()));
 		test_result.Check("ExecuteEntityJson", one, "1");
 
-	    ResultWithLog result = ExecuteEntityJsonPtrLogged(handle.data(), increment.data(), empty.data());
+		ResultWithLog result = ExecuteEntityJsonPtrLogged(handle.data(), increment.data(), empty.data());
 		ApiString json(result.json);
 		ApiString log(result.log);
 		test_result.Check("ExecuteEntityJsonPtrLogged json", json, "2");
@@ -214,7 +224,7 @@ static void ExecuteEntityJsonLoggedUpdating(TestResult &test_result)
 
 static void ExecuteEntityJsonLoggedRoundTrip(TestResult &test_result)
 {
-    LoadEntityStatus status = LoadEntity(handle.data(), filename.data(), empty.data(), false, empty.data(), empty.data(), empty.data());
+	LoadEntityStatus status = LoadEntity(handle.data(), filename.data(), empty.data(), false, empty.data(), empty.data(), empty.data(), nullptr, 0);
 	test_result.Require("LoadEntity", status.loaded);
 	if(test_result)
 	{
@@ -222,7 +232,7 @@ static void ExecuteEntityJsonLoggedRoundTrip(TestResult &test_result)
 		ExecuteEntity(handle.data(), initialize.data());
 
 		// Increment the counter, getting a log.
-	    ResultWithLog result = ExecuteEntityJsonPtrLogged(handle.data(), increment.data(), empty.data());
+		ResultWithLog result = ExecuteEntityJsonPtrLogged(handle.data(), increment.data(), empty.data());
 		ApiString json(result.json);
 		ApiString log(result.log);
 		test_result.Check("ExecuteEntityJsonPtrLogged json", json, "1");
@@ -237,7 +247,7 @@ static void ExecuteEntityJsonLoggedRoundTrip(TestResult &test_result)
 
 static void ExecuteEntityJsonLoggedTwice(TestResult &test_result)
 {
-    LoadEntityStatus status = LoadEntity(handle.data(), filename.data(), empty.data(), false, empty.data(), empty.data(), empty.data());
+	LoadEntityStatus status = LoadEntity(handle.data(), filename.data(), empty.data(), false, empty.data(), empty.data(), empty.data(), nullptr, 0);
 	test_result.Require("LoadEntity", status.loaded);
 	if(test_result)
 	{
@@ -245,13 +255,13 @@ static void ExecuteEntityJsonLoggedTwice(TestResult &test_result)
 		ExecuteEntity(handle.data(), initialize.data());
 
 		// Increment the counter, getting a log.
-	    ResultWithLog result1 = ExecuteEntityJsonPtrLogged(handle.data(), increment.data(), empty.data());
+		ResultWithLog result1 = ExecuteEntityJsonPtrLogged(handle.data(), increment.data(), empty.data());
 		ApiString json1(result1.json);
 		ApiString log1(result1.log);
 		test_result.Check("ExecuteEntityJsonPtrLogged json", json1, "1");
 
 		// Again.
-	    ResultWithLog result2 = ExecuteEntityJsonPtrLogged(handle.data(), increment.data(), empty.data());
+		ResultWithLog result2 = ExecuteEntityJsonPtrLogged(handle.data(), increment.data(), empty.data());
 		ApiString json2(result2.json);
 		ApiString log2(result2.log);
 		test_result.Check("ExecuteEntityJsonPtrLogged json", json2, "2");
@@ -267,7 +277,7 @@ static void ExecuteEntityJsonLoggedTwice(TestResult &test_result)
 
 static void ExecuteCounter2(TestResult &test_result)
 {
-    LoadEntityStatus status = LoadEntity(handle.data(), filename2.data(), empty.data(), false, empty.data(), empty.data(), empty.data());
+	LoadEntityStatus status = LoadEntity(handle.data(), filename2.data(), empty.data(), false, empty.data(), empty.data(), empty.data(), nullptr, 0);
 	test_result.Require("LoadEntity", status.loaded);
 	if(test_result)
 	{
@@ -288,7 +298,7 @@ static void ExecuteCounter2Logged(TestResult &test_result)
 {
 	// This is actually a test for a specific case of accum_entity_roots, via
 	// ExecuteEntityJsonPtrLogged(), that needs to preserve labels.
-    LoadEntityStatus status = LoadEntity(handle.data(), filename2.data(), empty.data(), false, empty.data(), empty.data(), empty.data());
+	LoadEntityStatus status = LoadEntity(handle.data(), filename2.data(), empty.data(), false, empty.data(), empty.data(), empty.data(), nullptr, 0);
 	test_result.Require("LoadEntity", status.loaded);
 	if(test_result)
 	{
@@ -312,7 +322,183 @@ static void ExecuteCounter2Logged(TestResult &test_result)
 	}
 }
 
-int main(int argc, char* argv[])
+static void TestLoadEntityFromMemory(TestResult &test_result)
+{
+	std::string amlg("(null #get_value \"hello\")");
+	LoadEntityStatus status = LoadEntityFromMemory(handle.data(), amlg.data(), amlg.size(), amlgSuffix.data(), false, empty.data(), empty.data(), empty.data(), nullptr, 0);
+	test_result.Require("LoadEntityFromMemory", status.loaded);
+	test_result.Require("LoadEntityFromMemory null entity_path", status.entity_path == nullptr);
+	test_result.Require("LoadEntityFromMemory zero entity_path_len", status.entity_path_len == 0);
+	if(test_result)
+	{
+		LoadedEntity loaded_entity(handle);
+		std::string result = ExecuteEntityJsonPtr(handle.data(), get_value.data(), empty.data());
+		test_result.Check("ExecuteEntityJsonPtr", result, "\"hello\"");
+	}
+}
+
+static void LoadSubEntityFromMemory(TestResult &test_result)
+{
+	LoadEntityStatus status = LoadEntity(handle.data(), filename2.data(), empty.data(), false, empty.data(), empty.data(), empty.data(), nullptr, 0);
+	test_result.Require("LoadEntity", status.loaded);
+	test_result.Require("LoadEntity null entity_path", status.entity_path == nullptr);
+	test_result.Require("LoadEntity zero entity_path_len", status.entity_path_len == 0);
+	if(test_result)
+	{
+		LoadedEntity loaded_entity(handle);
+		std::string amlg("(list #x 17)");
+		const char *entityPaths[] = { "test" };
+		status = LoadEntityFromMemory(handle.data(), amlg.data(), amlg.size(), amlgSuffix.data(), false, empty.data(), empty.data(), empty.data(), entityPaths, 1);
+		test_result.Require("LoadEntityFromMemory", status.loaded);
+		if(test_result)
+		{
+			test_result.Require("LoadEntityFromMemory non-null entity_path", status.entity_path != nullptr);
+			test_result.Require("LoadEntityFromMemory one entity_path_len", status.entity_path_len == 1);
+			if (test_result) {
+				test_result.Check("LoadEntityFromMemory first entity_path", status.entity_path[0], "test");
+			}
+			std::string input("{\"id\": \"test\"}");
+			std::string json = ExecuteEntityJsonPtr(handle.data(), get_value.data(), input.data());
+			test_result.Check("ExecuteEntityJsonPtr get_value", json, "17");
+		}
+	}
+}
+
+static void LoadSubSubEntityFromMemory(TestResult &test_result) {
+	std::string amlg("(list #x 17)");
+	LoadEntityStatus status = LoadEntityFromMemory(handle.data(), amlg.data(), amlg.size(), amlg.data(), false, empty.data(), empty.data(), empty.data(), nullptr, 0);
+	test_result.Require("LoadEntityFromMemory root", status.loaded);
+	if (test_result) {
+		const char *entityPaths[] = { "test", "sub" };
+		// 1. Loading just {test} produces just {test}
+		LoadEntityStatus status1 = LoadEntityFromMemory(handle.data(), amlg.data(), amlg.size(), amlg.data(), false, empty.data(), empty.data(), empty.data(), entityPaths, 1);
+		test_result.Require("LoadEntityFromMemory test1", status1.loaded);
+		test_result.Require("LoadEntityFromMemory test1 ep", status1.entity_path != nullptr);
+		test_result.Require("LoadEntityFromMemory test1 epl", status1.entity_path_len == 1);
+		if (test_result) {
+			test_result.Check("LoadEntityFromMemory test1 ep value", status1.entity_path[0], "test");
+		}
+		// 2. Loading just {test} when it already exists produces {test, _12345}
+		LoadEntityStatus status2 = LoadEntityFromMemory(handle.data(), amlg.data(), amlg.size(), amlg.data(), false, empty.data(), empty.data(), empty.data(), entityPaths, 1);
+		test_result.Require("LoadEntityFromMemory test2", status2.loaded);
+		test_result.Require("LoadEntityFromMemory test2 ep", status2.entity_path != nullptr);
+		test_result.Require("LoadEntityFromMemory test2 epl", status2.entity_path_len == 2);
+		if (test_result) {
+			test_result.Check("LoadEntityFromMemory test2 ep value", status2.entity_path[0], "test");
+			test_result.Require("LoadEntityFromMemory test2 value2", status2.entity_path[1][0] == '_');
+		}
+		// 3. Loading {test, sub} produces matching {test, sub}
+		LoadEntityStatus status3 = LoadEntityFromMemory(handle.data(), amlg.data(), amlg.size(), amlg.data(), false, empty.data(), empty.data(), empty.data(), entityPaths, 2);
+		test_result.Require("LoadEntityFromMemory test3", status3.loaded);
+		test_result.Require("LoadEntityFromMemory test3 ep", status3.entity_path != nullptr);
+		test_result.Require("LoadEntityFromMemory test3 epl", status3.entity_path_len == 2);
+		if (test_result) {
+			test_result.Check("LoadEntityFromMemory test3 ep value1", status3.entity_path[0], "test");
+			test_result.Check("LoadEntityFromMemory test3 ep value2", status3.entity_path[1], "sub");
+		}
+	}
+}
+
+static void TestStoreEntityToMemory(TestResult &test_result)
+{
+	// round-trip the trivial entity from TestLoadEntityFromMemory()
+	std::string amlg("(null #get_value \"hello\")");
+	LoadEntityStatus status = LoadEntityFromMemory(handle.data(), amlg.data(), amlg.size(), amlgSuffix.data(), false, empty.data(), empty.data(), empty.data(), nullptr, 0);
+	test_result.Require("LoadEntityFromMemory", status.loaded);
+	if(test_result)
+	{
+		LoadedEntity loaded_entity(handle);
+		void *data = nullptr;
+		size_t len = 0;
+		StoreEntityToMemory(handle.data(), &data, &len, amlgSuffix.data(), false, empty.data(), nullptr, 0);
+		char *cdata = reinterpret_cast<char *>(data);
+		std::string result(cdata, cdata + len);
+		// The actual result is very (very?) long and includes some boilerplate
+		test_result.Check("StoreEntityToMemory (prolog)", result.substr(0, declare.size()), declare);
+		test_result.Require("limit StoreEntityToMemory output to a reasonable size", result.size() < 4096);
+	}
+}
+
+static void StoreSubEntityToMemory(TestResult &test_result)
+{
+	// Do the same thing as ExecuteCounter2(), which stores the data in an
+	// embedded entity; then retrieve that entity.
+	LoadEntityStatus status = LoadEntity(handle.data(), filename2.data(), empty.data(), false, empty.data(), empty.data(), empty.data(), nullptr, 0);
+	test_result.Require("LoadEntity", status.loaded);
+	if(test_result)
+	{
+		LoadedEntity loaded_entity(handle);
+		ExecuteEntity(handle.data(), initialize.data());
+
+		std::string amlg("(retrieve_from_entity \"!id\")");
+		std::string idstr = EvalOnEntity(handle.data(), amlg.data());
+		test_result.Require("ID string is not empty", idstr.size() >= 2);
+		test_result.Require("ID string starts with a quote", idstr.front() == '"');
+		test_result.Require("ID string ends with a quote", idstr.back() == '"');
+		idstr.pop_back();
+		idstr.erase(0, 1);
+
+		ApiString result(ExecuteEntityJsonPtr(handle.data(), add.data(), empty.data()));
+		test_result.Check("ExecuteEntityJsonPtr add", result, "1");
+
+		void *data = nullptr;
+		size_t len = 0;
+		const char *entityPaths[] = { idstr.data() };
+		StoreEntityToMemory(handle.data(), &data, &len, amlgSuffix.data(), false, empty.data(), entityPaths, 1);
+		char *cdata = reinterpret_cast<char *>(data);
+		std::string stored(cdata, cdata + len);
+		// This is worth inspecting if you're unsure about it, but at the very center it contains only
+		// (lambda [##x 1])
+		// Some things we can check for
+		test_result.Check("StoreEntityToMemory (prolog)", stored.substr(0, declare.size()), declare);
+		test_result.Require("contain the entity contents", stored.find("##x 1") != std::string::npos);
+		test_result.Require("does not contain the parent entity contents", stored.find("get_value") == std::string::npos);
+	}
+}
+
+static void RoundTripCamlToMemory(TestResult &test_result)
+{
+	// Load the counter, bump it, dump it to an in-memory caml representation, then restore it.
+	LoadEntityStatus status = LoadEntity(handle.data(), filename.data(), empty.data(), false, empty.data(), empty.data(), empty.data(), nullptr, 0);
+	void *data = nullptr;
+	size_t len = 0;
+	test_result.Require("LoadEntity", status.loaded);
+	if(test_result)
+	{
+		LoadedEntity loaded_entity(handle);
+		ExecuteEntity(handle.data(), initialize.data());
+
+		ApiString incr(ExecuteEntityJsonPtr(handle.data(), increment.data(), empty.data()));
+		test_result.Check("ExecuteEntityJsonPtr increment", incr, "1");
+
+		StoreEntityToMemory(handle.data(), &data, &len, camlSuffix.data(), false, empty.data(), nullptr, 0);
+		test_result.Require("data pointer written by StoreEntityToMemory", data !=
+		 nullptr);
+		test_result.Require("content written by StoreEntityToMemory", len > 4);
+
+		// We've stored the data; let loaded_entity go out of scope so the entity can be destroyed
+	}
+	if(test_result)
+	{
+		char *cdata = reinterpret_cast<char *>(data);
+		std::string magic(cdata, cdata + 4);
+		test_result.Check("StoreEntityToMemory (magic number)", magic, "caml");
+	}
+	if(test_result)
+	{
+		LoadEntityStatus status = LoadEntityFromMemory(handle.data(), data, len, camlSuffix.data(), false, empty.data(), empty.data(), empty.data(), nullptr, 0);
+		test_result.Require("LoadEntityFromMemory", status.loaded);
+	}
+	if(test_result)
+	{
+		LoadedEntity loaded_entity(handle);
+
+		ApiString get(ExecuteEntityJsonPtr(handle.data(), get_value.data(), empty.data()));
+		test_result.Check("ExecuteEntityJsonPtr get_value", get, "1");
+	}
+}
+
+int main(int argc, char *argv[])
 {
 	bool verbose = false;
 
@@ -321,10 +507,10 @@ int main(int argc, char* argv[])
 		if(std::string("--help") == argv[i] || std::string("-h") == argv[i])
 		{
 			std::cout << "Usage: " << argv[0] << " [-h] [-v]" << std::endl
-			<< std::endl
-			<< "Options:" << std::endl
-			<< "  --help, -h     Print this help message" << std::endl
-			<< "  --verbose, -v  Print each test name as it executes" << std::endl;
+				<< std::endl
+				<< "Options:" << std::endl
+				<< "  --help, -h     Print this help message" << std::endl
+				<< "  --verbose, -v  Print each test name as it executes" << std::endl;
 			return 0;
 		}
 		else if(std::string("--verbose") == argv[i] || std::string("-v") == argv[i])
@@ -349,6 +535,12 @@ int main(int argc, char* argv[])
 	suite.Run("ExecuteEntityJsonLoggedTwice", ExecuteEntityJsonLoggedTwice);
 	suite.Run("ExecuteCounter2", ExecuteCounter2);
 	suite.Run("ExecuteCounter2Logged", ExecuteCounter2Logged);
+	suite.Run("TestLoadEntityFromMemory", TestLoadEntityFromMemory);
+	suite.Run("LoadSubEntityFromMemory", LoadSubEntityFromMemory);
+	suite.Run("LoadSubSubEntityFromMemory", LoadSubSubEntityFromMemory);
+	suite.Run("TestStoreEntityToMemory", TestStoreEntityToMemory);
+	suite.Run("StoreSubEntityToMemory", StoreSubEntityToMemory);
+	suite.Run("RoundTripCamlToMemory", RoundTripCamlToMemory);
 
 	return suite ? 0 : 1;
 }


### PR DESCRIPTION
Add new LoadEntityFromMemory()/StoreEntityToMemory() external API calls that take the entity contents from a pair of void *, size_t rather than a file.

For all of the Load/StoreEntity APIs, add a pair of char **, size_t parameters that identify a path to a non-root entity.  This allows loading or storing something nested potentially deep within the entity tree.

Existing calls to LoadEntity() and StoreEntity() need to add the additional entity-path parameters, which will usually be nullptr, 0.  If LoadEntity is passed a non-null entity path, then its return value will include an entity path as well, which needs to be separately freed.