### PR TITLE
Fix mutate_entity assigning contained entities the container's id

### DIFF
--- a/src/Amalgam/entity/EntityManipulation.cpp
+++ b/src/Amalgam/entity/EntityManipulation.cpp
@@ -648,7 +648,7 @@ Entity *EntityManipulation::MutateEntity(Interpreter *interpreter, Entity *entit
 	for(auto e : entity->GetContainedEntities())
 		new_entity->AddContainedEntity(MutateEntity(interpreter,
 			e, mutation_rate, mutation_weights, operation_type, preserve_type_depth,
-			imm_number_weights, imm_string_weights), entity->GetIdStringId());
+			imm_number_weights, imm_string_weights), e->GetIdStringId());
 
 	return new_entity;
 }


### PR DESCRIPTION
## Summary

`mutate_entity` assigns every mutated contained entity the **container's** id instead of the child's own id. As a result, a mutated copy loses the identities of its contained entities: with two or more contained entities, all but the first are silently dropped; a single contained entity is renamed to the container's id.

## Root cause

In `EntityManipulation::MutateEntity` (`src/Amalgam/entity/EntityManipulation.cpp:647-651`), each mutated child is added under `entity->GetIdStringId()` — the container's id — for every iteration of the loop:

```cpp
for(auto e : entity->GetContainedEntities())
    new_entity->AddContainedEntity(MutateEntity(interpreter,
        e, mutation_rate, mutation_weights, operation_type, preserve_type_depth,
        imm_number_weights, imm_string_weights), entity->GetIdStringId());
```

`AddContainedEntity` (`src/Amalgam/entity/Entity.cpp:614-620`) rejects a duplicate explicit id, returning `NOT_A_STRING_ID` without inserting the entity. So the first child is added under the container's id, and every subsequent child collides on that same id and is dropped.

This is independent of `mutation_rate`; it occurs at rate `0` because it is inherent to how the copy is assembled. The entity copy constructor (`Entity.cpp:81`) and `MergeContainedEntities` both key contained entities by the child's own id; `MutateEntity` is the only path that does not.

## Reproduction (engine-only)

```amalgam
(seq
    (create_entities "P" (associate "tag" "parent"))
    (create_entities (list "P" "h1") (associate "eval" 1))
    (create_entities (list "P" "h2") (associate "eval" 2))
    (mutate_entity "P" 0.0 "M")
    (print "source P children: " (contained_entities "P") "\n")
    (print "mutated M children: " (contained_entities "M") "\n"))
```

Expected `M` children: `["h1" "h2"]`. Actual: `["P"]` — `h2` dropped, `h1` renamed to `P`. Reproduced on engine 81.1.1.

## Impact

Any whole-entity `mutate_entity` on an entity that has one or more contained sub-entities loses child identity (two or more contained entities silently lose all but the first). This affects any use of contained sub-entities as part of an evolvable structure.

## Fix

Assign each mutated child its own id, matching the copy constructor and `MergeContainedEntities`:

```cpp
imm_number_weights, imm_string_weights), e->GetIdStringId());
```
