### PR TITLE
00000: Fix GCC 13/14 stringop-overflow false positive in NumberToString via std::to_chars, PATCH

### DIFF
--- a/src/Amalgam/string/StringManipulation.cpp
+++ b/src/Amalgam/string/StringManipulation.cpp
@@ -31,11 +31,9 @@ std::string StringManipulation::NumberToString(double value)
 
 std::string StringManipulation::NumberToString(size_t value)
 {
-	//use std::to_chars because regular string manipulation libraries are slow and measurably impact performance,
-	// and it avoids the GCC>=13 AVX2 stringop-overflow false positive triggered by a hand-rolled digit loop
 	char buffer[std::numeric_limits<size_t>::digits10 + 1];
-	auto result = std::to_chars(std::begin(buffer), std::end(buffer), value);
-	return std::string(buffer, result.ptr);
+	auto [end_ptr, error_code] = std::to_chars(std::begin(buffer), std::end(buffer), value);
+	return std::string(buffer, end_ptr);
 }
 
 std::string StringManipulation::RemoveFirstToken(std::string &str)

--- a/src/Amalgam/string/StringManipulation.cpp
+++ b/src/Amalgam/string/StringManipulation.cpp
@@ -8,6 +8,9 @@
 
 //system headers:
 #include <algorithm>
+#include <charconv>
+#include <iterator>
+#include <limits>
 #include <sstream>
 #include <string>
 
@@ -28,30 +31,11 @@ std::string StringManipulation::NumberToString(double value)
 
 std::string StringManipulation::NumberToString(size_t value)
 {
-	//do this our own way because regular string manipulation libraries are slow and measurably impact performance
-	constexpr size_t max_num_digits = std::numeric_limits<size_t>::digits / 3; //max of binary digits per character
-	constexpr size_t buffer_size = max_num_digits + 2;
-	char buffer[buffer_size];
-	char *p = &buffer[0];
-
-	if(value == 0) //check for zero because it's a very common case for integers
-		*p++ = '0';
-	else //convert each character
-	{
-		//peel off digits and put them in the next position for the string (reverse when done)
-		char *buffer_start = &buffer[0];
-		while(value != 0)
-		{
-			//pull off the least significant digit and convert it to a number character
-			*p++ = ('0' + (value % 10));
-			value /= 10;
-		}
-
-		//put back in original order
-		std::reverse(buffer_start, p);
-	}
-	*p = '\0';	//terminate string
-	return std::string(&buffer[0]);
+	//use std::to_chars because regular string manipulation libraries are slow and measurably impact performance,
+	// and it avoids the GCC>=13 AVX2 stringop-overflow false positive triggered by a hand-rolled digit loop
+	char buffer[std::numeric_limits<size_t>::digits10 + 1];
+	auto result = std::to_chars(std::begin(buffer), std::end(buffer), value);
+	return std::string(buffer, result.ptr);
 }
 
 std::string StringManipulation::RemoveFirstToken(std::string &str)


### PR DESCRIPTION
## Summary
- Replace the hand-rolled `StringManipulation::NumberToString(size_t)` digit loop/reverse with C++17 `std::to_chars`.
- Keep `NumberToString(double)` and all other code paths unchanged.
- Preserve the non-allocating/fast integer conversion intent while avoiding the GCC >= 13 AVX2 `-Werror=stringop-overflow` false positive from the old reversal loop.

## Root cause
GCC >= 13 with the repo's AVX2 advanced-intrinsics flags can vectorize the old digit-reversal path and fail to prove the loop bounds, diagnosing an infeasible write past `char buffer[23]`. The buffer was sufficient in practice, but `-Wall -Werror` made the false positive fatal on modern local GCC toolchains while CI's gcc-10 baseline stayed green.

## Repro / before-after
Problematic compile shape before this change:

```bash
g++ -std=c++17 -O3 -DNDEBUG -fPIC -fno-strict-aliasing -Wall \
  -Wno-unknown-pragmas -Werror -march=x86-64 -mavx2 \
  -I src/Amalgam -I src/Amalgam/string -I src/3rd_party \
  -c src/Amalgam/string/StringManipulation.cpp
```

After this change, the same command compiles cleanly on the worker's GCC 14.2.0.

## Verification
- `g++ -std=c++17 -O3 -DNDEBUG -fPIC -fno-strict-aliasing -Wall -Wno-unknown-pragmas -Werror -march=x86-64 -mavx2 -I src/Amalgam -I src/Amalgam/string -I src/3rd_party -c src/Amalgam/string/StringManipulation.cpp -o /tmp/StringManipulation.o` — passed on GCC 14.2.0.
- `AMALGAM_BUILD_VERSION=0.0.0-local cmake --preset amd64-release-linux-228` — passed.
- `cmake --build --preset amd64-release-linux-228 --target amalgam-st-app -- -j1` — passed; `StringManipulation.cpp` rebuilt and linked cleanly.
- `ctest --preset amd64-release-linux-228 -R 'amalgam-st-app' --output-on-failure` — passed, 3/3 tests.
- Spot check for `NumberToString(size_t)`: `0`, `9`, `12345`, and `SIZE_MAX` produced `0`, `9`, `12345`, `18446744073709551615`.
- Full `cmake --build --preset amd64-release-linux-228` attempts were made with `-j2` and `-j1`; both were killed by the 2 GiB worker limit (exit 137) while compiling additional targets. `StringManipulation.cpp` was no longer the blocker.
- Second-lane read-only Codex review found no blocking issues.
