### PR TITLE
25818: Fix inline format type string lifetime, PATCH

### DIFF
--- a/src/Amalgam/interpreter/OpcodesEntityLifecycleAndStorage.cpp
+++ b/src/Amalgam/interpreter/OpcodesEntityLifecycleAndStorage.cpp
@@ -95,7 +95,7 @@ EvaluableNodeReference Interpreter::InterpretNode_ENT_CREATE_ENTITIES(EvaluableN
 			continue;
 		}
 
-		auto new_entity_id_string = string_intern_pool.GetStringViewFromID(new_entity_id);
+		auto new_entity_id_string = string_intern_pool.GetStringViewFromID(new_entity_id.GetIDReference());
 		std::string rand_state = entity_container->CreateRandomStreamFromStringAndRand(new_entity_id_string);
 
 		//pause while allocating the new entity

--- a/src/Amalgam/interpreter/OpcodesVariableDefinitionAndModification.cpp
+++ b/src/Amalgam/interpreter/OpcodesVariableDefinitionAndModification.cpp
@@ -2011,7 +2011,7 @@ EvaluableNodeReference Interpreter::InterpretNode_ENT_FORMAT(EvaluableNode *en, 
 		}
 		else //need to parse the string
 		{
-			auto from_type_str = string_intern_pool.GetStringViewFromID(from_type);
+			auto from_type_str = string_intern_pool.GetStringViewFromID(from_type.GetIDReference());
 
 			//see if it starts with the date or time string
 			if(from_type_str.compare(0, date_string.size(), date_string) == 0)
@@ -2352,7 +2352,7 @@ EvaluableNodeReference Interpreter::InterpretNode_ENT_FORMAT(EvaluableNode *en, 
 	}
 	else //need to parse the string
 	{
-		auto to_type_str = string_intern_pool.GetStringViewFromID(to_type);
+		auto to_type_str = string_intern_pool.GetStringViewFromID(to_type.GetIDReference());
 
 		//if it starts with the date or time string
 		if(to_type_str.compare(0, date_string.size(), date_string) == 0)

--- a/src/Amalgam/string/StringInternPool.h
+++ b/src/Amalgam/string/StringInternPool.h
@@ -687,6 +687,11 @@ public:
 		return id;
 	}
 
+	inline const StringInternPool::StringID &GetIDReference() const noexcept
+	{
+		return id;
+	}
+
 	inline bool operator==(const StringInternPool::StringID &other) const noexcept
 	{
 		return id == other;


### PR DESCRIPTION
## Summary
- Fixes dangling `std::string_view` uses when `StringRef` values holding short inline IDs are passed to `GetStringViewFromID()`.
- Adds `StringRef::GetIDReference()` so call sites can view the stable `StringID` stored inside the `StringRef` instead of a temporary copy.
- Covers the reported `format` type-string path (`date:%S` / `date:%s`) plus the same latent pattern in `create_entities` random-stream seeding.
- Preserves the short-string pointer-tagging fast path: no heap allocation or string copy is added for inline IDs.

## Test Plan
- Reproduced the failure in `ghcr.io/howsoai/amalgam-build-container-linux-228:2.0.9` (GCC 10.3.1, glibc 2.28), at PR #622 head `9890acde24b890543f4050e07c210d9eff68026c`: `./out/build/amd64-release-linux-228/amalgam-st --validate-amalgam` failed format tests 33/35 (`date:%S` expected `"45"`, observed empty string; `date:%s` expected `" s"`, observed empty string).
- After the initial format-path patch in the same container/preset: `cmake --build --preset amd64-release-linux-228 --target amalgam-st-app -- -j2 && ./out/build/amd64-release-linux-228/amalgam-st --validate-amalgam` -> `All Tests Passed`.
- After the second-lane review fix for `create_entities`, in the same container/preset: `cmake --build --preset amd64-release-linux-228 -- -j4 && cmake --build --preset amd64-release-linux-228 --target test` -> `100% tests passed, 0 tests failed out of 13`.

## Review
- Codex identified the root cause and made the fix.
- Claude Code second-lane review confirmed the root cause/fix/performance reasoning and found the additional `create_entities` call site, now fixed in this PR.