### PR TITLE
00000: Fix read-only position kNN copy in SBFDS, PATCH

### DIFF
--- a/src/Amalgam/SeparableBoxFilterDataStore.h
+++ b/src/Amalgam/SeparableBoxFilterDataStore.h
@@ -677,19 +677,19 @@ public:
 		{
 			if(r_dist_eval.distEvaluator->computeSurprisal)
 				FindNearestEntities<true, true>(r_dist_eval, position_label_sids, top_k,
-					radius_label, enabled_indices, distances_out, ignore_entity_index, rand_stream);
+					radius_label, *possible_knn_indices, distances_out, ignore_entity_index, rand_stream);
 			else
 				FindNearestEntities<true, false>(r_dist_eval, position_label_sids, top_k,
-					radius_label, enabled_indices, distances_out, ignore_entity_index, rand_stream);
+					radius_label, *possible_knn_indices, distances_out, ignore_entity_index, rand_stream);
 		}
 		else
 		{
 			if(r_dist_eval.distEvaluator->computeSurprisal)
 				FindNearestEntities<false, true>(r_dist_eval, position_label_sids, top_k,
-					radius_label, enabled_indices, distances_out, ignore_entity_index, rand_stream);
+					radius_label, *possible_knn_indices, distances_out, ignore_entity_index, rand_stream);
 			else
 				FindNearestEntities<false, false>(r_dist_eval, position_label_sids, top_k,
-					radius_label, enabled_indices, distances_out, ignore_entity_index, rand_stream);
+					radius_label, *possible_knn_indices, distances_out, ignore_entity_index, rand_stream);
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Fixes `SeparableBoxFilterDataStore::FindEntitiesNearestToPosition` to pass the copied `*possible_knn_indices` into `FindNearestEntities` when `read_only_enabled_indices` is true.
- This matches `FindEntitiesNearestToIndexedEntity` and prevents read-only callers such as `KnnCache::GetKnnWithoutCache(position, ...)` from mutating the shared enabled/relevant entity set during kNN search.

## Investigation context
This was found while investigating a rare long-run crash in the SBFDS kNN/clustering path where `BitArrayIntegerSet::IterateOver` appeared to call the correct lambda with an index, but execution faulted in unrelated iterator code. I cannot claim this is the only possible cause of the reported 8-10h crash, but it is a concrete bug in the same SBFDS position-kNN path: the function builds a defensive copy for read-only callers and then ignored it on all four template dispatches.

## Verification
- `git diff --check`
- CI-faithful linux-228 container configure/build/smoke path:
  - `AMALGAM_BUILD_VERSION=0.0.0-local cmake --preset amd64-release-linux-228`
  - `cmake --build --preset amd64-release-linux-228 --target amalgam-mt-app -- -j2`
  - `./out/build/amd64-release-linux-228/amalgam-mt --validate-amalgam` -> `All Tests Passed`
  - Full linux-228 build + `cmake --build --preset amd64-release-linux-228 --target test` completed; `out/test/all_tests.log` reports `100% tests passed, 0 tests failed out of 13`.

## Residual risk
The original long federated run was not reproduced here, and the provided crash artifacts (`02-crash-thread*.txt`, `04-control-flow-evidence.txt`) were not present in the workspace/repo. If the crash persists after this fix, next probes should be TSan/ASan around SBFDS/EntityQueryCaches with watchpoints/asserts on `BitArrayIntegerSet` mutation and `PartialSumCollection::Accum` bounds.
